### PR TITLE
Switch mpris cover art cache to use a hash of the url 

### DIFF
--- a/src/ags.src.gresource.xml
+++ b/src/ags.src.gresource.xml
@@ -29,6 +29,7 @@
     <file>service/audio.js</file>
     <file>service/battery.js</file>
     <file>service/bluetooth.js</file>
+    <file>service/cache.js</file>
     <file>service/hyprland.js</file>
     <file>service/mpris.js</file>
     <file>service/network.js</file>

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ interface Config {
     style?: string
     notificationPopupTimeout?: number
     closeWindowDelay?: { [key: string]: number }
+    mediaCacheSize?: number
 }
 
 export default class App extends Gtk.Application {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import './service/apps.js';
 import './service/audio.js';
 import './service/battery.js';
 import './service/bluetooth.js';
+import './service/cache.js';
 import './service/hyprland.js';
 import './service/mpris.js';
 import './service/network.js';

--- a/src/service/cache.ts
+++ b/src/service/cache.ts
@@ -1,0 +1,231 @@
+import Service from './service.js';
+import { ensureDirectory, writeFile, readFile } from '../utils.js';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+import GdkPixbuf from 'gi://GdkPixbuf';
+import { CACHE_DIR } from '../utils.js';
+
+type cacheValue = {
+    filePath: string,
+    timestamp: number,
+};
+
+export class CacheService extends Service {
+    static {
+        Service.register(this, {
+            'cache-changed': ['string', 'string'],
+            'cache-repopulated': ['string'],
+            'cache-purged': ['string'],
+        });
+    }
+
+    private cacheLimits: { [key: string]: number };
+    private cachePaths: { [key: string]: string };
+    private caches: { [key: string]: { [key: string]: cacheValue } };
+
+    constructor() {
+        super();
+        this.cacheLimits = {};
+        this.cachePaths = {};
+        this.caches = {};
+    }
+
+    public NewCache(name: string, limit: number) {
+        this.cacheLimits[name] = limit;
+        this.cachePaths[name] = `${CACHE_DIR}/${name}`;
+        this.repopulateCache(name);
+    }
+
+    public AddPath(name: string, fetchPath: string) {
+        const key = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256,
+            fetchPath,
+            fetchPath.length) + '';
+
+        if (this.caches[name][key]) {
+            const err = new Error(`cache ${name} already has key ${key}`);
+            logError(err);
+            throw err;
+        }
+
+        this.caches[name][key] = {
+            filePath: `${this.cachePaths[name]}/${key}`,
+            timestamp: Date.now(),
+        };
+
+        this.writePath(fetchPath, this.caches[name][key].filePath);
+        this.writeIndex(name);
+        this.emit('cache-changed', name, this.caches[name][key].filePath);
+    }
+
+    public AddImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
+        if (this.caches[name][key]) {
+            const err = new Error(`cache ${name} already has key ${key}`);
+            logError(err);
+            throw err;
+        }
+
+        this.caches[name][key] = {
+            filePath: `${this.cachePaths[name]}/${key}`,
+            timestamp: Date.now(),
+        };
+        this.writeImage(this.caches[name][key].filePath, key, pixbuf);
+        this.writeIndex(name);
+        this.emit('cache-changed', name, this.caches[name][key].filePath);
+    }
+
+    public GetPath(name: string, fetchPath: string) {
+        const key = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256,
+            fetchPath,
+            fetchPath.length) + '';
+
+        if (!this.caches[name][key])
+            return '';
+
+        this.UpdateLastUsed(name, key);
+        return this.caches[name][key].filePath;
+    }
+
+    public GetImage(name: string, key: string) {
+        if (!this.caches[name][key])
+            return null;
+
+        this.UpdateLastUsed(name, key);
+
+        return GdkPixbuf.Pixbuf.new_from_file(this.caches[name][key].filePath);
+    }
+
+    public UpdateImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
+        if (!this.caches[name][key]) {
+            const err = new Error(`cache ${name} does not have key ${key}`);
+            logError(err);
+            throw err;
+        }
+
+        this.caches[name][key] = {
+            filePath: `${this.cachePaths[name]}/${key}`,
+            timestamp: Date.now(),
+        };
+        this.writeImage(this.caches[name][key].filePath, key, pixbuf);
+        this.writeIndex(name);
+        this.emit('cache-changed', name, this.caches[name][key].filePath);
+    }
+
+    private writeImage(path: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
+        const output_stream =
+            Gio.File.new_for_path(path)
+                .replace(null, false, Gio.FileCreateFlags.NONE, null);
+
+        pixbuf.save_to_streamv(output_stream, 'png', null, null, null);
+        output_stream.close(null);
+    }
+
+    private writePath(path: string, savePath: string) {
+        const file = Gio.File.new_for_uri(path);
+        const success = file.copy(
+            Gio.File.new_for_path(savePath),
+            Gio.FileCopyFlags.OVERWRITE,
+            GLib.PRIORITY_DEFAULT,
+            null,
+            // @ts-ignore
+            null,
+        );
+
+        if (!success)
+            throw new Error(`failed to copy ${path} to ${savePath}`);
+    }
+
+    private UpdateLastUsed(name: string, key: string) {
+        if (!this.caches[name][key]) {
+            const err = new Error(`cache ${name} does not have key ${key}`);
+            logError(err);
+            throw err;
+        }
+
+        this.caches[name][key].timestamp = Date.now();
+        this.writeIndex(name);
+    }
+
+    private repopulateCache(name: string) {
+        ensureDirectory(this.cachePaths[name]);
+        this.caches[name] = {};
+        const indexPath = this.cachePaths[name] + '/index';
+        if (GLib.file_test(indexPath, GLib.FileTest.EXISTS)) {
+            const cacheIndex = readFile(indexPath);
+            this.caches[name] = JSON.parse(cacheIndex);
+        } else {
+            this.writeIndex(name);
+        }
+        this.emit('cache-repopulated', name);
+    }
+
+    private writeIndex(name: string) {
+        this.checkAndPurge(name);
+        writeFile(JSON.stringify(this.caches[name]),
+            this.cachePaths[name] + '/index')
+            .catch(logError);
+    }
+
+    private checkAndPurge(name: string) {
+        if (Object.keys(this.caches[name]).length > this.cacheLimits[name])
+            this.CachePurgeOldest(name);
+    }
+
+    private CachePurgeOldest(name: string) {
+        let oldest = Infinity;
+        let oldestKey = '';
+        for (const key of Object.keys(this.caches[name])) {
+            if (this.caches[name][key].timestamp < oldest) {
+                oldest = this.caches[name][key].timestamp;
+                oldestKey = key;
+            }
+        }
+        if (!oldestKey)
+            return;
+
+        const okc = this.caches[name][oldestKey].filePath;
+        delete (this.caches[name][oldestKey]);
+        if (GLib.file_test(okc, GLib.FileTest.EXISTS)) {
+            const file = Gio.File.new_for_path(okc);
+            file.delete_async(GLib.PRIORITY_DEFAULT, null, null);
+        }
+        this.emit('cache-purged', name);
+    }
+}
+
+export default class Cache {
+    static { Service.export(this, 'cache'); }
+    static _instance: CacheService;
+
+    static get instance() {
+        Service.ensureInstance(Cache, CacheService);
+        return Cache._instance;
+    }
+
+    static NewCache(name: string, limit: number) {
+        Cache.instance.NewCache(name, limit);
+    }
+
+    static AddPath(name: string, fetchPath: string) {
+        Cache.instance.AddPath(name, fetchPath);
+    }
+
+    static AddImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
+        Cache.instance.AddImage(name, key, pixbuf);
+    }
+
+    static GetPath(name: string, fetchPath: string) {
+        return Cache.instance.GetPath(name, fetchPath);
+    }
+
+    static GetImage(name: string, key: string) {
+        return Cache.instance.GetImage(name, key);
+    }
+
+    static UpdateImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
+        Cache.instance.UpdateImage(name, key, pixbuf);
+    }
+
+    static Connect(signal: string, callback: (...args: any[]) => void) {
+        Cache.instance.connect(signal, callback);
+    }
+}

--- a/src/service/cache.ts
+++ b/src/service/cache.ts
@@ -122,7 +122,7 @@ export class CacheService extends Service {
             Gio.File.new_for_path(savePath),
             Gio.FileCopyFlags.OVERWRITE,
             null,
-            null
+            null,
         );
 
         if (!success)

--- a/src/service/cache.ts
+++ b/src/service/cache.ts
@@ -30,13 +30,13 @@ export class CacheService extends Service {
         this.caches = {};
     }
 
-    public NewCache(name: string, limit: number) {
+    newCache(name: string, limit: number) {
         this.cacheLimits[name] = limit;
         this.cachePaths[name] = `${CACHE_DIR}/${name}`;
         this.repopulateCache(name);
     }
 
-    public AddPath(name: string, fetchPath: string) {
+    addPath(name: string, fetchPath: string) {
         const key = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256,
             fetchPath,
             fetchPath.length) + '';
@@ -57,7 +57,7 @@ export class CacheService extends Service {
         this.emit('cache-changed', name, this.caches[name][key].filePath);
     }
 
-    public AddImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
+    addImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
         if (this.caches[name][key]) {
             const err = new Error(`cache ${name} already has key ${key}`);
             logError(err);
@@ -73,7 +73,7 @@ export class CacheService extends Service {
         this.emit('cache-changed', name, this.caches[name][key].filePath);
     }
 
-    public GetPath(name: string, fetchPath: string) {
+    getPath(name: string, fetchPath: string) {
         const key = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256,
             fetchPath,
             fetchPath.length) + '';
@@ -81,20 +81,20 @@ export class CacheService extends Service {
         if (!this.caches[name][key])
             return '';
 
-        this.UpdateLastUsed(name, key);
+        this.updateLastUsed(name, key);
         return this.caches[name][key].filePath;
     }
 
-    public GetImage(name: string, key: string) {
+    getImage(name: string, key: string) {
         if (!this.caches[name][key])
             return null;
 
-        this.UpdateLastUsed(name, key);
+        this.updateLastUsed(name, key);
 
         return GdkPixbuf.Pixbuf.new_from_file(this.caches[name][key].filePath);
     }
 
-    public UpdateImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
+    updateImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
         if (!this.caches[name][key]) {
             const err = new Error(`cache ${name} does not have key ${key}`);
             logError(err);
@@ -134,7 +134,7 @@ export class CacheService extends Service {
             throw new Error(`failed to copy ${path} to ${savePath}`);
     }
 
-    private UpdateLastUsed(name: string, key: string) {
+    private updateLastUsed(name: string, key: string) {
         if (!this.caches[name][key]) {
             const err = new Error(`cache ${name} does not have key ${key}`);
             logError(err);
@@ -167,10 +167,10 @@ export class CacheService extends Service {
 
     private checkAndPurge(name: string) {
         if (Object.keys(this.caches[name]).length > this.cacheLimits[name])
-            this.CachePurgeOldest(name);
+            this.cachePurgeOldest(name);
     }
 
-    private CachePurgeOldest(name: string) {
+    private cachePurgeOldest(name: string) {
         let oldest = Infinity;
         let oldestKey = '';
         for (const key of Object.keys(this.caches[name])) {
@@ -202,27 +202,27 @@ export default class Cache {
     }
 
     static NewCache(name: string, limit: number) {
-        Cache.instance.NewCache(name, limit);
+        Cache.instance.newCache(name, limit);
     }
 
     static AddPath(name: string, fetchPath: string) {
-        Cache.instance.AddPath(name, fetchPath);
+        Cache.instance.addPath(name, fetchPath);
     }
 
     static AddImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
-        Cache.instance.AddImage(name, key, pixbuf);
+        Cache.instance.addImage(name, key, pixbuf);
     }
 
     static GetPath(name: string, fetchPath: string) {
-        return Cache.instance.GetPath(name, fetchPath);
+        return Cache.instance.getPath(name, fetchPath);
     }
 
     static GetImage(name: string, key: string) {
-        return Cache.instance.GetImage(name, key);
+        return Cache.instance.getImage(name, key);
     }
 
     static UpdateImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
-        Cache.instance.UpdateImage(name, key, pixbuf);
+        Cache.instance.updateImage(name, key, pixbuf);
     }
 
     static Connect(signal: string, callback: (...args: any[]) => void) {

--- a/src/service/cache.ts
+++ b/src/service/cache.ts
@@ -19,16 +19,9 @@ export class CacheService extends Service {
         });
     }
 
-    private cacheLimits: { [key: string]: number };
-    private cachePaths: { [key: string]: string };
-    private caches: { [key: string]: { [key: string]: cacheValue } };
-
-    constructor() {
-        super();
-        this.cacheLimits = {};
-        this.cachePaths = {};
-        this.caches = {};
-    }
+    private cacheLimits: { [key: string]: number } = {};
+    private cachePaths: { [key: string]: string } = {};
+    private caches: { [key: string]: { [key: string]: cacheValue } } = {};
 
     newCache(name: string, limit: number) {
         this.cacheLimits[name] = limit;
@@ -193,7 +186,7 @@ export class CacheService extends Service {
 }
 
 export default class Cache {
-    static { Service.export(this, 'cache'); }
+    static { Service.export(this, 'Cache'); }
     static _instance: CacheService;
 
     static get instance() {

--- a/src/service/cache.ts
+++ b/src/service/cache.ts
@@ -45,9 +45,11 @@ export class CacheService extends Service {
             timestamp: Date.now(),
         };
 
-        this.writePath(fetchPath, this.caches[name][key].filePath);
+        const filePath = this.caches[name][key].filePath;
+        this.writePath(fetchPath, filePath);
         this.writeIndex(name);
-        this.emit('cache-changed', name, this.caches[name][key].filePath);
+        this.emit('cache-changed', name, filePath);
+        return filePath;
     }
 
     addImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
@@ -61,9 +63,11 @@ export class CacheService extends Service {
             filePath: `${this.cachePaths[name]}/${key}`,
             timestamp: Date.now(),
         };
-        this.writeImage(this.caches[name][key].filePath, key, pixbuf);
+        const filePath = this.caches[name][key].filePath;
+        this.writeImage(filePath, key, pixbuf);
         this.writeIndex(name);
-        this.emit('cache-changed', name, this.caches[name][key].filePath);
+        this.emit('cache-changed', name, filePath);
+        return filePath;
     }
 
     getPath(name: string, fetchPath: string) {
@@ -117,10 +121,8 @@ export class CacheService extends Service {
         const success = file.copy(
             Gio.File.new_for_path(savePath),
             Gio.FileCopyFlags.OVERWRITE,
-            GLib.PRIORITY_DEFAULT,
             null,
-            // @ts-ignore
-            null,
+            null
         );
 
         if (!success)
@@ -142,12 +144,14 @@ export class CacheService extends Service {
         ensureDirectory(this.cachePaths[name]);
         this.caches[name] = {};
         const indexPath = this.cachePaths[name] + '/index';
+
         if (GLib.file_test(indexPath, GLib.FileTest.EXISTS)) {
             const cacheIndex = readFile(indexPath);
             this.caches[name] = JSON.parse(cacheIndex);
         } else {
             this.writeIndex(name);
         }
+
         this.emit('cache-repopulated', name);
     }
 
@@ -199,11 +203,11 @@ export default class Cache {
     }
 
     static AddPath(name: string, fetchPath: string) {
-        Cache.instance.addPath(name, fetchPath);
+        return Cache.instance.addPath(name, fetchPath);
     }
 
     static AddImage(name: string, key: string, pixbuf: GdkPixbuf.Pixbuf) {
-        Cache.instance.addImage(name, key, pixbuf);
+        return Cache.instance.addImage(name, key, pixbuf);
     }
 
     static GetPath(name: string, fetchPath: string) {

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -63,6 +63,13 @@ class MprisPlayer extends GObject.Object {
 
         Cache.NewCache(CACHE_KEY, App.config?.mediaCacheSize || 100);
 
+        Cache.Connect('cache-changed', (_, name, path) => {
+            if (name !== CACHE_KEY && this.coverPath !== path)
+                return;
+            this.coverPath = path;
+            this.emit('changed');
+        });
+
         this.busName = busName;
         this.name = busName.substring(23).split('.')[0];
 
@@ -122,6 +129,7 @@ class MprisPlayer extends GObject.Object {
             trackTitle = 'Unknown title';
 
         let trackCoverUrl = metadata['mpris:artUrl'];
+
         if (typeof trackCoverUrl !== 'string')
             trackCoverUrl = '';
 
@@ -154,7 +162,7 @@ class MprisPlayer extends GObject.Object {
         }
         this.coverPath = Cache.GetPath(CACHE_KEY, this.trackCoverUrl);
         if (!this.coverPath)
-            this.coverPath = Cache.AddPath(CACHE_KEY, this.trackCoverUrl);
+            Cache.AddPath(CACHE_KEY, this.trackCoverUrl);
     }
 
     get volume() {

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -149,16 +149,13 @@ class MprisPlayer extends GObject.Object {
     }
 
     _cacheCoverArt() {
-        this.coverPath = MEDIA_CACHE_PATH + '/' +
-            `${this.trackArtists.join(', ')}-${this.trackTitle}`
-                .replace(/[\,\*\?\"\<\>\|\#\:\?\/\'\(\)]/g, '');
-
-        if (this.coverPath.length > 255)
-            this.coverPath = this.coverPath.substring(0, 255);
-
         const { trackCoverUrl, coverPath } = this;
-        if (trackCoverUrl === '' || coverPath === '')
+        if (trackCoverUrl === '') {
+            this.coverPath = '';
             return;
+        }
+
+        this.coverPath = MEDIA_CACHE_PATH + '/' + GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256, trackCoverUrl, 255);
 
         if (GLib.file_test(coverPath, GLib.FileTest.EXISTS))
             return;

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -235,8 +235,11 @@ class MprisPlayer extends GObject.Object {
                 oldestKey = key;
             }
         }
-        delete (this._coverCache[oldestKey]);
+        if (!oldestKey)
+            return;
+
         const okc = this._coverCache[oldestKey].coverPath;
+        delete (this._coverCache[oldestKey]);
         if (GLib.file_test(okc, GLib.FileTest.EXISTS)) {
             const file = Gio.File.new_for_path(okc);
             file.delete_async(GLib.PRIORITY_DEFAULT, null, null);

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -76,7 +76,6 @@ class MprisPlayer extends GObject.Object {
         this._onPlayerProxyReady();
 
         Cache.Connect('cache-changed', (name: string, path: string) => {
-            logError(new Error(`${name} also changed at ${path}`));
             if (name == CACHE_KEY) {
                 this.emit('changed');
                 this.coverPath = path;
@@ -84,13 +83,11 @@ class MprisPlayer extends GObject.Object {
         });
 
         Cache.Connect('cache-repolulated', (name: string) => {
-            logError(new Error(`${name} repopulated`));
             if (name == CACHE_KEY)
                 this._updateState.bind(this);
         });
 
         Cache.NewCache(CACHE_KEY, App.config?.mediaCacheSize || 100);
-        logError(new Error(`new player ${busName}`));
     }
 
     close() {

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -57,6 +57,7 @@ class MprisPlayer extends GObject.Object {
     _binding: { mpris: number, player: number };
     _mprisProxy: MprisProxy;
     _playerProxy: PlayerProxy;
+    _pendingCover = false;
 
     constructor(busName: string) {
         super();
@@ -67,6 +68,7 @@ class MprisPlayer extends GObject.Object {
             if (name !== CACHE_KEY && this.coverPath !== path)
                 return;
             this.coverPath = path;
+            this._pendingCover = false;
             this.emit('changed');
         });
 
@@ -152,17 +154,22 @@ class MprisPlayer extends GObject.Object {
         this.trackCoverUrl = trackCoverUrl;
         this.length = length;
         this._cacheCoverArt();
-        this.emit('changed');
+        if (!this._pendingCover)
+            this.emit('changed');
     }
 
     _cacheCoverArt() {
         if (!this.trackCoverUrl) {
             this.coverPath = '';
+            this._pendingCover = false;
             return;
         }
         this.coverPath = Cache.GetPath(CACHE_KEY, this.trackCoverUrl);
-        if (!this.coverPath)
+        this._pendingCover = false;
+        if (!this.coverPath) {
+            this._pendingCover = true;
             Cache.AddPath(CACHE_KEY, this.trackCoverUrl);
+        }
     }
 
     get volume() {

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -173,16 +173,20 @@ class MprisPlayer extends GObject.Object {
 
     _repopulateCoverCache() {
         const cachePath = MEDIA_CACHE_PATH + '/covercache.json';
+        ensureDirectory(MEDIA_CACHE_PATH);
+
         if (!GLib.file_test(cachePath, GLib.FileTest.EXISTS)) {
         this._coverCache = {};
             return;
         }
+
         const file = Gio.File.new_for_path(cachePath);
         const fileResult = file.load_contents(null);
         if (!fileResult[0]) {
         this._coverCache = {};
             return;
         }
+
         try {
             const cacheCovers = new TextDecoder().decode(fileResult[1]);
             this._coverCache = JSON.parse(cacheCovers);

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -160,8 +160,10 @@ class MprisPlayer extends GObject.Object {
             this.coverPath = '';
             return;
         }
-
-        const hash = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256, this.trackCoverUrl, this.trackCoverUrl.length) + '';
+        const tc = this.trackCoverUrl;
+        const tcl = tc.length;
+        const shaFlag = GLib.ChecksumType.SHA256;
+        const hash = GLib.compute_checksum_for_string(shaFlag, tc, tcl) + '';
         if (this._coverCache[hash]) {
             this.coverPath = this._coverCache[hash].coverPath;
             this._coverCache[hash].timestamp = Date.now();
@@ -190,7 +192,6 @@ class MprisPlayer extends GObject.Object {
         try {
             const cacheCovers = new TextDecoder().decode(fileResult[1]);
             this._coverCache = JSON.parse(cacheCovers);
-            log(`loaded ${Object.keys(this._coverCache).length} covers from cover cache`);
         } catch (e) {
             logError(e as Error, `failed to parse ${cachePath}`);
             this._coverCache = {};
@@ -233,7 +234,9 @@ class MprisPlayer extends GObject.Object {
 
         const cachePath = MEDIA_CACHE_PATH + '/covercache.json';
         const file = Gio.File.new_for_path(cachePath);
-        const result = file.replace_contents(JSON.stringify(this._coverCache), null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
+        const jsOut = JSON.stringify(this._coverCache);
+        const repFlag = Gio.FileCreateFlags.REPLACE_DESTINATION;
+        const result = file.replace_contents(jsOut, null, false, repFlag, null);
         if (!result[0])
             logError(new Error(`failed to write ${cachePath}`));
 
@@ -250,9 +253,9 @@ class MprisPlayer extends GObject.Object {
             }
         }
         delete (this._coverCache[oldestKey]);
-
-        if (GLib.file_test(this._coverCache[oldestKey].coverPath, GLib.FileTest.EXISTS)) {
-            const file = Gio.File.new_for_path(this._coverCache[oldestKey].coverPath);
+        const okc = this._coverCache[oldestKey].coverPath;
+        if (GLib.file_test(okc, GLib.FileTest.EXISTS)) {
+            const file = Gio.File.new_for_path(okc);
             file.delete_async(GLib.PRIORITY_DEFAULT, null, null);
         }
     }

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -222,8 +222,8 @@ class MprisPlayer extends GObject.Object {
         if (Object.keys(this._coverCache).length > this._cacheSize)
             this._coverCachePurgeOldest();
 
-        writeFile(MprisPlayer.cachePath,
-            JSON.stringify(this._coverCache)).catch(logError);
+        writeFile(JSON.stringify(this._coverCache),
+            MprisPlayer.cachePath).catch(logError);
     }
 
     _coverCachePurgeOldest() {

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -186,7 +186,6 @@ class MprisPlayer extends GObject.Object {
         try {
             const cacheCovers = new TextDecoder().decode(fileResult[1]);
             this._coverCache = JSON.parse(cacheCovers);
-            log(this._coverCache);
             log(`loaded ${Object.keys(this._coverCache).length} covers from cover cache`);
         } catch (e) {
             logError(e as Error, `failed to parse ${cachePath}`);

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -161,14 +161,14 @@ class MprisPlayer extends GObject.Object {
             return;
         }
 
-        const hash = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256, this.trackCoverUrl, this.trackCoverUrl.length) + "";
+        const hash = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256, this.trackCoverUrl, this.trackCoverUrl.length) + '';
         if (this._coverCache[hash]) {
             this.coverPath = this._coverCache[hash].coverPath;
             this._coverCache[hash].timestamp = Date.now();
             return;
         }
 
-        this.coverPath = this._coverCacheAdd(hash, this.trackCoverUrl);       
+        this.coverPath = this._coverCacheAdd(hash, this.trackCoverUrl);
     }
 
     _repopulateCoverCache() {
@@ -176,14 +176,14 @@ class MprisPlayer extends GObject.Object {
         ensureDirectory(MEDIA_CACHE_PATH);
 
         if (!GLib.file_test(cachePath, GLib.FileTest.EXISTS)) {
-        this._coverCache = {};
+            this._coverCache = {};
             return;
         }
 
         const file = Gio.File.new_for_path(cachePath);
         const fileResult = file.load_contents(null);
         if (!fileResult[0]) {
-        this._coverCache = {};
+            this._coverCache = {};
             return;
         }
 
@@ -218,7 +218,7 @@ class MprisPlayer extends GObject.Object {
                 }
                 catch (e) {
                     logError(e as Error, `failed to cache ${trackCoverUrl}`);
-                    return "";
+                    return '';
                 }
             },
         );
@@ -228,16 +228,14 @@ class MprisPlayer extends GObject.Object {
             timestamp: Date.now(),
         };
 
-        if (Object.keys(this._coverCache).length > 100) {
+        if (Object.keys(this._coverCache).length > 100)
             this._coverCachePurgeOldest();
-        }
 
         const cachePath = MEDIA_CACHE_PATH + '/covercache.json';
         const file = Gio.File.new_for_path(cachePath);
         const result = file.replace_contents(JSON.stringify(this._coverCache), null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
-        if (!result[0]) {
+        if (!result[0])
             logError(new Error(`failed to write ${cachePath}`));
-        }
 
         return coverPath;
     }
@@ -251,7 +249,7 @@ class MprisPlayer extends GObject.Object {
                 oldestKey = key;
             }
         }
-        delete(this._coverCache[oldestKey]);
+        delete (this._coverCache[oldestKey]);
 
         if (GLib.file_test(this._coverCache[oldestKey].coverPath, GLib.FileTest.EXISTS)) {
             const file = Gio.File.new_for_path(this._coverCache[oldestKey].coverPath);


### PR DESCRIPTION
This fixes an issue where if the track + artist name is missing you would get whatever the cover art for the first track with those missing you listened to is.  This way as long as there is a url for the cover art you will always get the correct one back.

The original bug happens for me when opening spotify with a track paused as it will return cover art via mpris but no artist or track title (gotta love spotify bugs).