### PR TITLE
only destroy children that aren't re-used

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
     dontBuild = true;
 
-    npmDepsHash = "sha256-9EOpgm3Hg5MO9JIRNBgqmAA2Pf1QxgU1QGo+VVa1WjM=";
+    npmDepsHash = "sha256-uNdmlQIwXoO8Ls0qjJnwRGqpfiJK1PajAvoiHfJXcxg=";
 
     installPhase = ''
       mkdir $out

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ags",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ags",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "GPL",
       "dependencies": {
         "@girs/gvc-1.0": "^1.0.0-3.1.0",

--- a/src/widgets/box.ts
+++ b/src/widgets/box.ts
@@ -24,12 +24,20 @@ export default class AgsBox extends Gtk.Box {
 
     get children() { return this.get_children(); }
     set children(children: Gtk.Widget[] | null) {
-        this.get_children().forEach(ch => ch.destroy());
+        const newChildren = children || [];
+            
+        this.get_children()
+            .filter((ch) => !newChildren?.includes(ch))
+            .forEach((ch) => ch.destroy());
 
-        if (!children)
-            return;
+        // remove any children that weren't destroyed so
+        // we can re-add everything in the correct new order
+        this.get_children()
+            .forEach(ch => this.remove(ch));
+            
+        if (!children) return;
 
-        children.forEach(w => w && this.add(w));
+        children.forEach((w) => w && this.add(w));
         this.show_all();
     }
 

--- a/src/widgets/box.ts
+++ b/src/widgets/box.ts
@@ -25,19 +25,20 @@ export default class AgsBox extends Gtk.Box {
     get children() { return this.get_children(); }
     set children(children: Gtk.Widget[] | null) {
         const newChildren = children || [];
-            
+
         this.get_children()
-            .filter((ch) => !newChildren?.includes(ch))
-            .forEach((ch) => ch.destroy());
+            .filter(ch => !newChildren?.includes(ch))
+            .forEach(ch => ch.destroy());
 
         // remove any children that weren't destroyed so
         // we can re-add everything in the correct new order
         this.get_children()
             .forEach(ch => this.remove(ch));
-            
-        if (!children) return;
 
-        children.forEach((w) => w && this.add(w));
+        if (!children)
+            return;
+
+        children.forEach(w => w && this.add(w));
         this.show_all();
     }
 

--- a/src/widgets/button.ts
+++ b/src/widgets/button.ts
@@ -80,6 +80,9 @@ export default class AgsButton extends Gtk.Button {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
+        
+        if (widget === child) return;
+
         if (widget)
             widget.destroy();
 

--- a/src/widgets/button.ts
+++ b/src/widgets/button.ts
@@ -80,8 +80,9 @@ export default class AgsButton extends Gtk.Button {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
-        
-        if (widget === child) return;
+
+        if (widget === child)
+            return;
 
         if (widget)
             widget.destroy();

--- a/src/widgets/centerbox.ts
+++ b/src/widgets/centerbox.ts
@@ -27,7 +27,10 @@ export default class AgsCenterBox extends AgsBox {
     }
 
     set children(children: Gtk.Widget[] | null) {
-        this.get_children().forEach(ch => ch.destroy());
+        const newChildren = children || [];
+
+        newChildren.filter((ch) => !newChildren?.includes(ch))
+            .forEach(ch => ch.destroy());
 
         if (!children)
             return;

--- a/src/widgets/centerbox.ts
+++ b/src/widgets/centerbox.ts
@@ -29,7 +29,7 @@ export default class AgsCenterBox extends AgsBox {
     set children(children: Gtk.Widget[] | null) {
         const newChildren = children || [];
 
-        newChildren.filter((ch) => !newChildren?.includes(ch))
+        newChildren.filter(ch => !newChildren?.includes(ch))
             .forEach(ch => ch.destroy());
 
         if (!children)

--- a/src/widgets/eventbox.ts
+++ b/src/widgets/eventbox.ts
@@ -95,6 +95,8 @@ export default class AgsEventBox extends Gtk.EventBox {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
+        if (widget === child) return;
+        
         if (widget)
             widget.destroy();
 

--- a/src/widgets/eventbox.ts
+++ b/src/widgets/eventbox.ts
@@ -95,8 +95,9 @@ export default class AgsEventBox extends Gtk.EventBox {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
-        if (widget === child) return;
-        
+        if (widget === child)
+            return;
+
         if (widget)
             widget.destroy();
 

--- a/src/widgets/menu.ts
+++ b/src/widgets/menu.ts
@@ -80,8 +80,9 @@ export class AgsMenuItem extends Gtk.MenuItem {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
-        if (widget === child) return;
-        
+        if (widget === child)
+            return;
+
         if (widget)
             widget.destroy();
 

--- a/src/widgets/menu.ts
+++ b/src/widgets/menu.ts
@@ -80,6 +80,8 @@ export class AgsMenuItem extends Gtk.MenuItem {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
+        if (widget === child) return;
+        
         if (widget)
             widget.destroy();
 

--- a/src/widgets/overlay.ts
+++ b/src/widgets/overlay.ts
@@ -38,6 +38,8 @@ export default class AgsOverlay extends Gtk.Overlay {
     get child() { return this._child; }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
+        if (widget === child) return;
+        
         if (widget)
             widget.destroy();
 
@@ -50,8 +52,14 @@ export default class AgsOverlay extends Gtk.Overlay {
     get overlays() { return this._overlays; }
     set overlays(overlays: Gtk.Widget[]) {
         overlays ||= [];
-        this.get_children().filter(ch => ch !== this._child)
+        this.get_children().filter(
+            ch => ch !== this._child
+                // && !overlays.includes(ch)
+            )
             .forEach(ch => ch.destroy());
+
+        // this.get_children()
+        //     .forEach(ch => this.remove_overlay(ch));
 
         this._overlays = [];
         overlays.forEach(ch => this.add_overlay(ch));
@@ -60,5 +68,10 @@ export default class AgsOverlay extends Gtk.Overlay {
     add_overlay(widget: Gtk.Widget): void {
         this._overlays.push(widget);
         super.add_overlay(widget);
+    }
+
+    remove_overlay(widget: Gtk.Widget): void {
+        //why is ts complaining remove_overlay doesn't exist?
+        //super.remove_overlay(widget);
     }
 }

--- a/src/widgets/overlay.ts
+++ b/src/widgets/overlay.ts
@@ -38,8 +38,9 @@ export default class AgsOverlay extends Gtk.Overlay {
     get child() { return this._child; }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
-        if (widget === child) return;
-        
+        if (widget === child)
+            return;
+
         if (widget)
             widget.destroy();
 
@@ -54,12 +55,12 @@ export default class AgsOverlay extends Gtk.Overlay {
         overlays ||= [];
         this.get_children().filter(
             ch => ch !== this._child
-                // && !overlays.includes(ch)
-            )
+                && !overlays.includes(ch),
+        )
             .forEach(ch => ch.destroy());
 
-        // this.get_children()
-        //     .forEach(ch => this.remove_overlay(ch));
+        this.get_children()
+            .forEach(ch => this.remove_overlay(ch));
 
         this._overlays = [];
         overlays.forEach(ch => this.add_overlay(ch));
@@ -71,7 +72,6 @@ export default class AgsOverlay extends Gtk.Overlay {
     }
 
     remove_overlay(widget: Gtk.Widget): void {
-        //why is ts complaining remove_overlay doesn't exist?
-        //super.remove_overlay(widget);
+        super.remove(widget);
     }
 }

--- a/src/widgets/overlay.ts
+++ b/src/widgets/overlay.ts
@@ -6,17 +6,6 @@ export default class AgsOverlay extends Gtk.Overlay {
         GObject.registerClass({
             GTypeName: 'AgsOverlay',
             Properties: {
-                'child': GObject.ParamSpec.object(
-                    'child', 'Child', 'Child',
-                    GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
-                    Gtk.Widget.$gtype,
-                ),
-                // @ts-ignore
-                'overlays': GObject.ParamSpec.jsobject(
-                    'overlays', 'Overlays', 'Overlays',
-                    GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
-                    [],
-                ),
                 'pass-through': GObject.ParamSpec.boolean(
                     'pass-through', 'Pass Through', 'Pass Through',
                     GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
@@ -24,6 +13,11 @@ export default class AgsOverlay extends Gtk.Overlay {
                 ),
             },
         }, this);
+    }
+
+    constructor({ overlays = [], ...rest } = {}) {
+        super(rest);
+        this.overlays = overlays;
     }
 
     _passthrough = false;
@@ -34,8 +28,8 @@ export default class AgsOverlay extends Gtk.Overlay {
             this.set_overlay_pass_through(ch, passthrough));
     }
 
-    _child!: Gtk.Widget;
-    get child() { return this._child; }
+    // @ts-ignore
+    get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
         if (widget === child)
@@ -44,7 +38,6 @@ export default class AgsOverlay extends Gtk.Overlay {
         if (widget)
             widget.destroy();
 
-        this._child = child;
         if (child)
             this.add(child);
     }
@@ -52,26 +45,24 @@ export default class AgsOverlay extends Gtk.Overlay {
     _overlays!: Gtk.Widget[];
     get overlays() { return this._overlays; }
     set overlays(overlays: Gtk.Widget[]) {
-        overlays ||= [];
-        this.get_children().filter(
-            ch => ch !== this._child
-                && !overlays.includes(ch),
-        )
+        this.get_children()
+            .filter(ch => ch !== this.child && !overlays.includes(ch))
             .forEach(ch => ch.destroy());
 
         this.get_children()
-            .forEach(ch => this.remove_overlay(ch));
+            .filter(ch => ch !== this.child)
+            .forEach(ch => this.remove(ch));
 
         this._overlays = [];
         overlays.forEach(ch => this.add_overlay(ch));
+
+        // reset passthrough
+        this.get_children().forEach(ch =>
+            this.set_overlay_pass_through(ch, this.pass_through));
     }
 
     add_overlay(widget: Gtk.Widget): void {
         this._overlays.push(widget);
         super.add_overlay(widget);
-    }
-
-    remove_overlay(widget: Gtk.Widget): void {
-        super.remove(widget);
     }
 }

--- a/src/widgets/revealer.ts
+++ b/src/widgets/revealer.ts
@@ -40,6 +40,8 @@ export default class AgsRevealer extends Gtk.Revealer {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
+        if (widget === child) return;
+        
         if (widget)
             widget.destroy();
 

--- a/src/widgets/revealer.ts
+++ b/src/widgets/revealer.ts
@@ -40,8 +40,9 @@ export default class AgsRevealer extends Gtk.Revealer {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
-        if (widget === child) return;
-        
+        if (widget === child)
+            return;
+
         if (widget)
             widget.destroy();
 

--- a/src/widgets/scrollable.ts
+++ b/src/widgets/scrollable.ts
@@ -34,8 +34,9 @@ export default class AgsScrollable extends Gtk.ScrolledWindow {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
-        if (widget === child) return;
-        
+        if (widget === child)
+            return;
+
         if (widget)
             widget.destroy();
 

--- a/src/widgets/scrollable.ts
+++ b/src/widgets/scrollable.ts
@@ -34,6 +34,8 @@ export default class AgsScrollable extends Gtk.ScrolledWindow {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
+        if (widget === child) return;
+        
         if (widget)
             widget.destroy();
 

--- a/src/widgets/stack.ts
+++ b/src/widgets/stack.ts
@@ -44,15 +44,15 @@ export default class AgsStack extends Gtk.Stack {
     set items(items: [string, Gtk.Widget][]) {
         this._items
             .filter(([name]) => !items.find(([n]) => n === name))
-            .forEach(([_, ch]) => ch.destroy());
-        
+            .forEach(([, ch]) => ch.destroy());
+
         // remove any children that weren't destroyed so
         // we can re-add everything without trying to add
         // items multiple times
         this._items
-            .filter(([_, ch]) => this.get_children().includes(ch))
-            .forEach(([_, ch]) => this.remove(ch));
-        
+            .filter(([, ch]) => this.get_children().includes(ch))
+            .forEach(([, ch]) => this.remove(ch));
+
         this._items = [];
         items.forEach(([name, widget]) => {
             widget && this.add_named(widget, name);

--- a/src/widgets/stack.ts
+++ b/src/widgets/stack.ts
@@ -42,7 +42,17 @@ export default class AgsStack extends Gtk.Stack {
     _items: [string, Gtk.Widget][] = [];
     get items() { return this._items; }
     set items(items: [string, Gtk.Widget][]) {
-        this.get_children().forEach(ch => ch.destroy());
+        this._items
+            .filter(([name]) => !items.find(([n]) => n === name))
+            .forEach(([_, ch]) => ch.destroy());
+        
+        // remove any children that weren't destroyed so
+        // we can re-add everything without trying to add
+        // items multiple times
+        this._items
+            .filter(([_, ch]) => this.get_children().includes(ch))
+            .forEach(([_, ch]) => this.remove(ch));
+        
         this._items = [];
         items.forEach(([name, widget]) => {
             widget && this.add_named(widget, name);

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -174,7 +174,8 @@ export default class AgsWindow extends Gtk.Window {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
-        if (widget === child) return;
+        if (widget === child)
+            return;
 
         if (widget)
             widget.destroy();

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -174,6 +174,8 @@ export default class AgsWindow extends Gtk.Window {
     get child() { return this.get_child(); }
     set child(child: Gtk.Widget) {
         const widget = this.get_child();
+        if (widget === child) return;
+
         if (widget)
             widget.destroy();
 


### PR DESCRIPTION
This is my first PR to an open-source project, let me know if there's anything I need to add/do.

When the children array or child is set on any widget, only widgets that aren't also in the new array should be destroyed.
There may be cases where widgets are being re-used (eg.. images that are created and cached in a service) - destroying them before re-adding them causes errors.

~~NOTE: I don't know why typescript is complaining that remove_overlay doesn't exist on Overlay widget, it's in the docs.. See commented out code.~~