### PR TITLE
fix touchpad scrolling for eventboxes

### DIFF
--- a/src/widgets/eventbox.ts
+++ b/src/widgets/eventbox.ts
@@ -35,6 +35,7 @@ export default class AgsEventBox extends Gtk.EventBox {
     } = {}) {
         super(params);
         this.add_events(Gdk.EventMask.SCROLL_MASK);
+        this.add_events(Gdk.EventMask.SMOOTH_SCROLL_MASK);
 
         this.onPrimaryClick = onPrimaryClick;
         this.onSecondaryClick = onSecondaryClick;
@@ -82,11 +83,9 @@ export default class AgsEventBox extends Gtk.EventBox {
         });
 
         this.connect('scroll-event', (box, event) => {
-            if (event.get_scroll_direction()[1] ===
-                Gdk.ScrollDirection.UP)
+            if (event.get_scroll_deltas()[2] < 0)
                 return runCmd(this.onScrollUp, box, event);
-            else if (event.get_scroll_direction()[1] ===
-                Gdk.ScrollDirection.DOWN)
+            else if (event.get_scroll_deltas()[2] > 0)
                 return runCmd(this.onScrollDown, box, event);
         });
     }


### PR DESCRIPTION
This PR should fix #5 

This adds an additional SMOOTH_SCROLL_MASK event and adjusts the `scroll-event` signal handler for eventboxes accordingly.

I'm still fairly new to JS so it's possible I might have overlooked something however this should be a small and simple change.