### PR TITLE
update version to 1.1.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('ags',
-          version: '1.0.0',
+          version: '1.1.0',
     meson_version: '>= 0.62.0',
     	  license: ['GPL-3.0-or-later'],
   default_options: [ 'warning_level=2', 'werror=false', ],

--- a/nix/ags.nix
+++ b/nix/ags.nix
@@ -30,7 +30,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "ags";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = buildNpmPackage {
     name = "ags";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ags",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ags",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "GPL",
             "dependencies": {
                 "@girs/dbusmenugtk3-0.4": "^0.4.0-3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ags",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "description",
     "main": "src/main.ts",
     "repository": "",


### PR DESCRIPTION
I think you forgot to update the versions to 1.1.0 on the package.json and the meson.build.

You would have to force push  the v1.1.0 tag again