### PR TITLE
service getters return Array instead of Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Aylur's Gtk Shell
 
-This program is essentially a library for gjs which allows defining GTK widgets in a declarative way in JavaScript. It also provides services to interact with the system so that these widgets can have functionality. It was heavily inspired by [EWW](https://github.com/elkowar/eww).
+This is a library built for [GJS](https://gitlab.gnome.org/GNOME/gjs) to allow defining GTK widgets in a declarative way. It also provides services and other utilites to interact with the system so that these widgets can have functionality.
+GJS is a JavaScript runtime built on Firefox's SpiderMonkey JavaScript engine and the GNOME platform libraries, the same runtine [GNOME Shell](https://gitlab.gnome.org/GNOME/gnome-shell) runs on. 
+
+It was heavily inspired by [EWW](https://github.com/elkowar/eww).
 
 Currently only Wayland is supported, but there are plans for X11.
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('ags',
-          version: '1.0.0',
+          version: '1.1.0',
     meson_version: '>= 0.62.0',
     	  license: ['GPL-3.0-or-later'],
   default_options: [ 'warning_level=2', 'werror=false', ],

--- a/nix/ags.nix
+++ b/nix/ags.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
 
     dontBuild = true;
 
-    npmDepsHash = "sha256-4BNbFi/Ltg/8tuicrrMBIdOhteEIs85Zqj9oI/hYbl0=";
+    npmDepsHash = "sha256-wbDReZxU/MtHYNSf1mb7iDoTlR0NlSc60kdSpk81UCU=";
 
     installPhase = ''
       mkdir $out

--- a/nix/ags.nix
+++ b/nix/ags.nix
@@ -30,7 +30,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "ags";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = buildNpmPackage {
     name = "ags";

--- a/nix/gjs.nix
+++ b/nix/gjs.nix
@@ -30,6 +30,7 @@
 , gtk-layer-shell
 , libdbusmenu-gtk3
 , libsoup_3
+, gvfs
 }:
 
 let
@@ -81,6 +82,7 @@ in stdenv.mkDerivation rec {
     spidermonkey_102
     libdbusmenu-gtk3
     libsoup_3
+    gvfs
   ];
 
   nativeCheckInputs = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ags",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ags",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "GPL",
             "dependencies": {
                 "@girs/dbusmenugtk3-0.4": "^0.4.0-3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ags",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "description",
     "main": "src/main.ts",
     "repository": "",

--- a/src/ags.src.gresource.xml
+++ b/src/ags.src.gresource.xml
@@ -14,6 +14,7 @@
     <file>widgets/box.js</file>
     <file>widgets/button.js</file>
     <file>widgets/centerbox.js</file>
+    <file>widgets/circularprogress.js</file>
     <file>widgets/entry.js</file>
     <file>widgets/eventbox.js</file>
     <file>widgets/icon.js</file>
@@ -21,7 +22,6 @@
     <file>widgets/menu.js</file>
     <file>widgets/overlay.js</file>
     <file>widgets/progressbar.js</file>
-    <file>widgets/circularprogress.js</file>
     <file>widgets/revealer.js</file>
     <file>widgets/scrollable.js</file>
     <file>widgets/slider.js</file>

--- a/src/ags.src.gresource.xml
+++ b/src/ags.src.gresource.xml
@@ -21,6 +21,7 @@
     <file>widgets/menu.js</file>
     <file>widgets/overlay.js</file>
     <file>widgets/progressbar.js</file>
+    <file>widgets/circularprogress.js</file>
     <file>widgets/revealer.js</file>
     <file>widgets/scrollable.js</file>
     <file>widgets/slider.js</file>

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ interface Config {
     style?: string
     notificationPopupTimeout?: number
     closeWindowDelay?: { [key: string]: number }
+    maxStreamVolume: number
 }
 
 export default class App extends Gtk.Application {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -1,6 +1,7 @@
 import Service from './service.js';
 import GObject from 'gi://GObject';
 import Gvc from 'gi://Gvc';
+import App from '../app.js';
 import { bulkConnect, bulkDisconnect } from '../utils.js';
 
 class Stream extends Service {
@@ -47,8 +48,8 @@ class Stream extends Service {
     }
 
     set volume(value) { // 0..100
-        if (value > 1.5)
-            value = 1.5;
+        if (value > (App.config.maxStreamVolume || 1.5))
+            value = (App.config.maxStreamVolume || 1.5);
 
         if (value < 0)
             value = 0;

--- a/src/service/bluetooth.ts
+++ b/src/service/bluetooth.ts
@@ -143,6 +143,8 @@ class BluetoothService extends Service {
         );
     }
 
+    getDevice(address: string) { return this._devices.get(address); }
+
     set enabled(v) { this._client.default_adapter_powered = v; }
     get enabled() { return this.state === 'on' || this.state === 'turning-on'; }
 
@@ -156,14 +158,14 @@ class BluetoothService extends Service {
         }
     }
 
-    get devices() { return this._devices; }
+    get devices() { return Array.from(this._devices.values()); }
     get connectedDevices() {
-        const map = new Map();
-        for (const [address, device] of this._devices) {
+        const list = [];
+        for (const [, device] of this._devices) {
             if (device.connected)
-                map.set(address, device);
+                list.push(device);
         }
-        return map;
+        return list;
     }
 }
 
@@ -175,8 +177,10 @@ export default class Bluetooth {
         return Bluetooth._instance;
     }
 
+    static getDevice(address: string) { return Bluetooth.instance.getDevice(address); }
+
+    static get devices() { return Bluetooth.instance.devices; }
     static get connectedDevices() { return Bluetooth.instance.connectedDevices; }
     static get enabled() { return Bluetooth.instance.enabled; }
     static set enabled(enable: boolean) { Bluetooth.instance.enabled = enable; }
-    static get devices() { return Bluetooth.instance.devices; }
 }

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -229,10 +229,14 @@ export default class Hyprland {
         return Hyprland._instance;
     }
 
+    static getMonitor(id: number) { return Hyprland.instance.monitors.get(id); }
+    static getWorkspace(id: number) { return Hyprland.instance.workspaces.get(id); }
+    static getClient(address: string) { return Hyprland.instance.clients.get(address); }
+
+    static get monitors() { return Array.from(Hyprland.instance.monitors.values()); }
+    static get workspaces() { return Array.from(Hyprland.instance.workspaces.values()); }
+    static get clients() { return Array.from(Hyprland.instance.clients.values()); }
     static get active() { return Hyprland.instance.active; }
-    static get monitors() { return Hyprland.instance.monitors; }
-    static get workspaces() { return Hyprland.instance.workspaces; }
-    static get clients() { return Hyprland.instance.clients; }
 
     static HyprctlGet(cmd: string): unknown | object {
         const [success, out, err] =

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -311,10 +311,7 @@ class MprisService extends Service {
             this._addPlayer(name);
     }
 
-    getPlayer(name: string | ((players: Players) => MprisPlayer) = '') {
-        if (typeof name === 'function')
-            return name(new Map(this._players)) || null;
-
+    getPlayer(name: string) {
         for (const [busName, player] of this._players) {
             if (busName.includes(name))
                 return player;
@@ -331,7 +328,7 @@ export default class Mpris {
         return Mpris._instance;
     }
 
-    static getPlayer(name: string | ((players: Players) => MprisPlayer)) {
+    static getPlayer(name: string) {
         return Mpris.instance.getPlayer(name);
     }
 

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -252,6 +252,8 @@ class MprisService extends Service {
     private _players!: Players;
     private _proxy: DBusProxy;
 
+    get players() { return Array.from(this._players.values()); }
+
     constructor() {
         super();
 
@@ -330,6 +332,8 @@ export default class Mpris {
     }
 
     static getPlayer(name: string | ((players: Players) => MprisPlayer)) {
-        return Mpris._instance.getPlayer(name);
+        return Mpris.instance.getPlayer(name);
     }
+
+    static get players() { return Mpris.instance.players; }
 }

--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -3,7 +3,7 @@ import GObject from 'gi://GObject';
 import Service from './service.js';
 import { bulkConnect } from '../utils.js';
 
-const _INTERNET = (device: NM.Device) => {
+const INTERNET = (device: NM.Device) => {
     switch (device?.active_connection?.state) {
         case NM.ActiveConnectionState.ACTIVATED: return 'connected';
         case NM.ActiveConnectionState.ACTIVATING: return 'connecting';
@@ -13,7 +13,7 @@ const _INTERNET = (device: NM.Device) => {
     }
 };
 
-const _DEVICE_STATE = (device: NM.Device) => {
+const DEVICE_STATE = (device: NM.Device) => {
     switch (device?.state) {
         case NM.DeviceState.UNMANAGED: return 'unmanaged';
         case NM.DeviceState.UNAVAILABLE: return 'unavailable';
@@ -31,7 +31,7 @@ const _DEVICE_STATE = (device: NM.Device) => {
     }
 };
 
-const _CONNECTIVITY_STATE = (client: NM.Client) => {
+const CONNECTIVITY_STATE = (client: NM.Client) => {
     switch (client.connectivity) {
         case NM.ConnectivityState.NONE: return 'none';
         case NM.ConnectivityState.PORTAL: return 'portal';
@@ -41,7 +41,15 @@ const _CONNECTIVITY_STATE = (client: NM.Client) => {
     }
 };
 
-const _DEVICE = (device: string) => {
+const STRENGHT_ICONS = [
+    { value: 80, icon: 'network-wireless-signal-excellent-symbolic' },
+    { value: 60, icon: 'network-wireless-signal-good-symbolic' },
+    { value: 40, icon: 'network-wireless-signal-ok-symbolic' },
+    { value: 20, icon: 'network-wireless-signal-weak-symbolic' },
+    { value: 0, icon: 'network-wireless-signal-none-symbolic' },
+];
+
+const DEVICE = (device: string) => {
     switch (device) {
         case '802-11-wireless': return 'wifi';
         case '802-3-ethernet': return 'wired';
@@ -101,6 +109,7 @@ class Wifi extends Service {
                 : 'Unknown',
             active: ap === this._ap,
             strength: ap.strength,
+            iconName: STRENGHT_ICONS.find(({ value }) => value <= ap.strength)?.icon,
         }));
     }
 
@@ -108,7 +117,7 @@ class Wifi extends Service {
     set enabled(v) { this._client.wireless_enabled = v; }
 
     get strength() { return this._ap?.strength || -1; }
-    get internet() { return _INTERNET(this._device); }
+    get internet() { return INTERNET(this._device); }
     get ssid() {
         if (!this._ap)
             return '';
@@ -120,7 +129,7 @@ class Wifi extends Service {
         return NM.utils_ssid_to_utf8(ssid);
     }
 
-    get state() { return _DEVICE_STATE(this._device); }
+    get state() { return DEVICE_STATE(this._device); }
     get iconName() {
         const iconNames: [number, string][] = [
             [80, 'excellent'],
@@ -158,8 +167,8 @@ class Wired extends Service {
     }
 
     get speed() { return this._device.get_speed(); }
-    get internet() { return _INTERNET(this._device); }
-    get state() { return _DEVICE_STATE(this._device); }
+    get internet() { return INTERNET(this._device); }
+    get state() { return DEVICE_STATE(this._device); }
     get iconName() {
         if (this.internet === 'connecting')
             return 'network-wired-acquiring-symbolic';
@@ -230,8 +239,8 @@ class NetworkService extends Service {
             this._client.get_primary_connection() ||
             this._client.get_activating_connection();
 
-        this._primary = _DEVICE(mainConnection?.type || '');
-        this._connectivity = _CONNECTIVITY_STATE(this._client);
+        this._primary = DEVICE(mainConnection?.type || '');
+        this._connectivity = CONNECTIVITY_STATE(this._client);
         this.emit('changed');
     }
 }

--- a/src/service/notifications.ts
+++ b/src/service/notifications.ts
@@ -273,8 +273,12 @@ export default class Notifications {
     static clear() { Notifications.instance.Clear(); }
     static close(id: number) { Notifications.instance.CloseNotification(id); }
 
+    static getPopup(id: number) { return Notifications.instance.popups.get(id); }
+    static getNotification(id: number) { return Notifications.instance.notifications.get(id); }
+
+    static get popups() { return Array.from(Notifications.instance.popups.values()); }
+    static get notifications() { return Array.from(Notifications.instance.notifications.values()); }
+
     static get dnd() { return Notifications.instance.dnd; }
     static set dnd(value: boolean) { Notifications.instance.dnd = value; }
-    static get popups() { return Notifications.instance.popups; }
-    static get notifications() { return Notifications.instance.notifications; }
 }

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -20,7 +20,7 @@ class AgsVariable extends GObject.Object {
     _inerval?: number;
     _subprocess?: Gio.Subprocess | null;
 
-    constructor(value: any, option: Options) {
+    constructor(value: any, option: Options = {}) {
         super();
         this.value = value;
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -14,6 +14,7 @@ import AgsProgressBar from './widgets/progressbar.js';
 import AgsEntry from './widgets/entry.js';
 import { AgsMenu, AgsMenuItem } from './widgets/menu.js';
 import AgsWindow from './widgets/window.js';
+import AgsCircularProgress from './widgets/circularprogress.js';
 import { constructor, type ctor } from './widgets/constructor.js';
 
 export default function Widget({ type, ...params }: { type: ctor }) {
@@ -37,6 +38,7 @@ export const Revealer = (args: object) => constructor(AgsRevealer, args);
 export const Scrollable = (args: object) => constructor(AgsScrollable, args);
 export const Slider = (args: object) => constructor(AgsSlider, args);
 export const Stack = (args: object) => constructor(AgsStack, args);
+export const CircularProgress = (args: object) => constructor(AgsCircularProgress, args);
 
 // so it is still in global scope through ags.Widget
 Widget.Widget = Widget;
@@ -56,3 +58,4 @@ Widget.Scrollable = Scrollable;
 Widget.Slider = Slider;
 Widget.Stack = Stack;
 Widget.Window = Window;
+Widget.CircularProgress = CircularProgress;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -26,6 +26,7 @@ export const Window = (args: object) => constructor(AgsWindow, args);
 export const Box = (args: object) => constructor(AgsBox, args);
 export const Button = (args: object) => constructor(AgsButton, args);
 export const CenterBox = (args: object) => constructor(AgsCenterBox, args);
+export const CircularProgress = (args: object) => constructor(AgsCircularProgress, args);
 export const Entry = (args: object) => constructor(AgsEntry, args);
 export const EventBox = (args: object) => constructor(AgsEventBox, args);
 export const Icon = (args: object) => constructor(AgsIcon, args);
@@ -38,13 +39,13 @@ export const Revealer = (args: object) => constructor(AgsRevealer, args);
 export const Scrollable = (args: object) => constructor(AgsScrollable, args);
 export const Slider = (args: object) => constructor(AgsSlider, args);
 export const Stack = (args: object) => constructor(AgsStack, args);
-export const CircularProgress = (args: object) => constructor(AgsCircularProgress, args);
 
 // so it is still in global scope through ags.Widget
 Widget.Widget = Widget;
 Widget.Box = Box;
 Widget.Button = Button;
 Widget.CenterBox = CenterBox;
+Widget.CircularProgress = CircularProgress;
 Widget.Entry = Entry;
 Widget.EventBox = EventBox;
 Widget.Icon = Icon;
@@ -58,4 +59,3 @@ Widget.Scrollable = Scrollable;
 Widget.Slider = Slider;
 Widget.Stack = Stack;
 Widget.Window = Window;
-Widget.CircularProgress = CircularProgress;

--- a/src/widgets/circularprogress.ts
+++ b/src/widgets/circularprogress.ts
@@ -1,0 +1,182 @@
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk?version=3.0';
+
+// type from gi-types is wrong
+interface Context {
+    setSourceRGBA: (r: number, g: number, b: number, a: number) => void
+    arc: (x: number, y: number, r: number, a1: number, a2: number) => void
+    setLineWidth: (w: number) => void
+    lineTo: (x: number, y: number) => void
+    stroke: () => void
+    fill: () => void
+}
+
+interface Params {
+    start_at: number,
+    startAt: number,
+    value: number,
+    inverted: boolean,
+    rounded: boolean,
+}
+
+export default class AgsCircularProgress extends Gtk.Bin {
+    static {
+        GObject.registerClass({
+            GTypeName: 'AgsCircularProgress',
+            Properties: {
+                'start-at': GObject.ParamSpec.double(
+                    'start-at', 'Start At', 'The percentage that the circle should start at',
+                    GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+                    0, 1, 0,
+                ),
+                'inverted': GObject.ParamSpec.boolean(
+                    'inverted', 'Inverted', 'Inverted',
+                    GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+                    true,
+                ),
+                'rounded': GObject.ParamSpec.boolean(
+                    'rounded', 'Rounded', 'Rounded',
+                    GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+                    true,
+                ),
+                'value': GObject.ParamSpec.double(
+                    'value', 'Value', 'The progress percentage',
+                    GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+                    0, 1, 0,
+                ),
+            },
+        }, this);
+    }
+
+    constructor({ startAt, start_at, inverted, value, rounded, ...rest }: Params) {
+        super(rest);
+
+        if (start_at || startAt)
+            this.start_at = start_at || startAt;
+
+        if (typeof inverted === 'boolean')
+            this.inverted = inverted;
+
+        if (typeof rounded === 'boolean')
+            this.rounded = rounded;
+
+        if (value)
+            this.value = value;
+    }
+
+    private _rounded = true;
+    get rounded() { return this._rounded; }
+    set rounded(r: boolean) {
+        this._rounded = r;
+        this.queue_draw();
+    }
+
+    private _inverted = true;
+    get inverted() { return this._inverted; }
+    set inverted(c: boolean) {
+        this._inverted = c;
+        this.queue_draw();
+    }
+
+    private _startAt = 0;
+    get start_at() { return this._startAt; }
+    set start_at(value: number) {
+        if (value > 1)
+            value = 1;
+
+        if (value < 0)
+            value = 0;
+
+        this._startAt = value;
+        this.queue_draw();
+    }
+
+    private _value = 0;
+    get value() { return this._value; }
+    set value(value: number) {
+        if (value > 1)
+            value = 1;
+
+        if (value < 0)
+            value = 0;
+
+        this._value = value;
+        this.queue_draw();
+    }
+
+    vfunc_get_preferred_height(): [number, number] {
+        let minHeight = this.get_style_context()
+            .get_property('min-height', Gtk.StateFlags.NORMAL) as number;
+        if (minHeight <= 0)
+            minHeight = 40;
+
+        return [minHeight, minHeight];
+    }
+
+    vfunc_get_preferred_width(): [number, number] {
+        let minWidth = this.get_style_context()
+            .get_property('min-width', Gtk.StateFlags.NORMAL) as number;
+        if (minWidth <= 0)
+            minWidth = 40;
+
+        return [minWidth, minWidth];
+    }
+
+    private _toRadian(percentage: number) {
+        percentage = Math.floor(percentage * 100);
+        return (percentage / 100) * (2 * Math.PI);
+    }
+
+    vfunc_draw(cr: Context): boolean {
+        const allocation = this.get_allocation();
+        const styles = this.get_style_context();
+        const width = allocation.width;
+        const height = allocation.height;
+        const thickness = styles.get_property('font-size', Gtk.StateFlags.NORMAL) as number;
+        const margin = styles.get_margin(Gtk.StateFlags.NORMAL);
+        const fg = styles.get_color(Gtk.StateFlags.NORMAL);
+        const bg = styles.get_background_color(Gtk.StateFlags.NORMAL);
+        const bgStroke = thickness + Math.min(margin.bottom, margin.top, margin.left, margin.right);
+        const fgStroke = thickness;
+        const radius = Math.min(width, height) / 2.0 - Math.max(bgStroke, fgStroke) / 2.0;
+        const center = { x: width / 2, y: height / 2 };
+        const from = this._toRadian(this.start_at);
+        const to = this._toRadian(this.value + this.start_at);
+
+        // Draw background
+        cr.setSourceRGBA(bg.red, bg.green, bg.blue, bg.alpha);
+        cr.arc(center.x, center.y, radius, 0, 2 * Math.PI);
+        cr.setLineWidth(bgStroke);
+        cr.stroke();
+
+        // Draw progress
+        cr.setSourceRGBA(fg.red, fg.green, fg.blue, fg.alpha);
+        cr.arc(center.x, center.y, radius, this.inverted ? from : to, this.inverted ? to : from);
+        cr.setLineWidth(fgStroke);
+        cr.stroke();
+
+        // Draw rounded ends
+        if (this.rounded) {
+            const start = {
+                x: center.x + Math.cos(from) * radius,
+                y: center.y + Math.sin(from) * radius,
+            };
+            const end = {
+                x: center.x + Math.cos(to) * radius,
+                y: center.y + Math.sin(to) * radius,
+            };
+            cr.setLineWidth(0);
+            cr.arc(start.x, start.y, fgStroke / 2, 0, 0 - 0.01);
+            cr.fill();
+            cr.arc(end.x, end.y, fgStroke / 2, 0, 0 - 0.01);
+            cr.fill();
+        }
+
+        if (this.child) {
+            this.child.size_allocate(allocation);
+            this.propagate_draw(this.child, cr);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Currently services that have a `Map` containing objects like `Hyprland.workspaces` or `Bluetooth.devices` return their internal `Map` object. With this PR `getter` methods return an Array that can be easily iterated through with `map` and will have a `get<Item>` method that will still offer a way to get items by their id.
```js
// instead of
Box({
  children: Array.from(Hyprland.workspaces.values()).map(ws => /* widget */),
});
const ws = Hyprland.workspaces.get(0);

// now
Box({
  children: Hyprland.workspaces.map(ws => /* widget */),
});
const ws = Hyprland.getWorkspace(0);
```

~Also renamed `Audio.microphone` to `Audio.source` and `Audio.speaker` to `Audio.sink`~