### PR TITLE
fix trayIcons using custom iconTheme

### DIFF
--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -51,10 +51,12 @@ export class TrayItem extends Service {
     }
 
     scroll(event: Gdk.EventScroll) {
-        const direction =
-            (event.direction == 0 || event.direction == 1) ? 'vertical' : 'horizontal';
-        const delta =
-            (event.direction == 0 || event.direction == 1) ? event.delta_y : event.delta_x;
+        const direction = (event.direction == 0 || event.direction == 1)
+            ? 'vertical' : 'horizontal';
+
+        const delta = (event.direction == 0 || event.direction == 1)
+            ? event.delta_y : event.delta_x;
+
         this._proxy.ScrollAsync(delta, direction);
     }
 
@@ -78,31 +80,28 @@ export class TrayItem extends Service {
         let tooltipMarkup = this._proxy.ToolTip[2];
         if (this._proxy.ToolTip[3] !== '')
             tooltipMarkup += '\n' + this._proxy.ToolTip[3];
+
         return tooltipMarkup;
     }
 
     get icon() {
-        let icon;
         const iconName = this.status === 'NeedsAttention'
             ? this._proxy.AttentionIconName
             : this._proxy.IconName;
+
         if (this._iconTheme && iconName) {
             const size = Math.max(...this._iconTheme.get_icon_sizes(iconName));
             const iconInfo = this._iconTheme.lookup_icon(
                 iconName, size, Gtk.IconLookupFlags.FORCE_SIZE);
-            if (iconInfo) {
-                icon = iconInfo.load_icon();
-                return icon;
-            }
+
+            if (iconInfo)
+                return iconInfo.load_icon();
         }
         const iconPixmap = this.status === 'NeedsAttention'
             ? this._proxy.AttentionIconPixmap
             : this._proxy.IconPixmap;
-        icon = iconName
-            ? iconName
-            : this._getPixbuf(iconPixmap);
 
-        return icon || 'image-missing';
+        return iconName || this._getPixbuf(iconPixmap) || 'image-missing';
     }
 
     private _itemProxyAcquired(proxy: StatusNotifierItemProxy) {

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -69,7 +69,6 @@ export class TrayItem extends Service {
     get status() { return this._proxy.Status; }
     get windowId() { return this._proxy.WindowId; }
     get isMenu() { return this._proxy.ItemIsMenu; }
-    get iconThemePath() { return this._proxy.IconThemePath; }
 
     get tooltipMarkup() {
         if (!this._proxy.ToolTip)
@@ -107,6 +106,9 @@ export class TrayItem extends Service {
             });
             this.menu = (menu as unknown) as DbusmenuGtk3.Menu;
         }
+
+        if (this._proxy.IconThemePath)
+            Gtk.IconTheme.get_default().append_search_path(this._proxy.IconThemePath);
 
         bulkConnect(proxy, [
             ['notify::g-name-owner', () => {

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -69,6 +69,7 @@ export class TrayItem extends Service {
     get status() { return this._proxy.Status; }
     get windowId() { return this._proxy.WindowId; }
     get isMenu() { return this._proxy.ItemIsMenu; }
+    get iconThemePath() { return this._proxy.IconThemePath; }
 
     get tooltipMarkup() {
         if (!this._proxy.ToolTip)
@@ -106,9 +107,6 @@ export class TrayItem extends Service {
             });
             this.menu = (menu as unknown) as DbusmenuGtk3.Menu;
         }
-
-        if (this._proxy.IconThemePath)
-            Gtk.IconTheme.get_default().append_search_path(this._proxy.IconThemePath);
 
         bulkConnect(proxy, [
             ['notify::g-name-owner', () => {

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -81,6 +81,8 @@ export class TrayItem extends Service {
     }
 
     get icon() {
+        if (this._proxy.IconThemePath)
+            Gtk.IconTheme.get_default().append_search_path(this._proxy.IconThemePath);
         let icon;
         if (this.status === 'NeedsAttention') {
             icon = this._proxy.AttentionIconName

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -81,8 +81,6 @@ export class TrayItem extends Service {
     }
 
     get icon() {
-        if (this._proxy.IconThemePath)
-            Gtk.IconTheme.get_default().append_search_path(this._proxy.IconThemePath);
         let icon;
         if (this.status === 'NeedsAttention') {
             icon = this._proxy.AttentionIconName
@@ -108,6 +106,9 @@ export class TrayItem extends Service {
             });
             this.menu = (menu as unknown) as DbusmenuGtk3.Menu;
         }
+
+        if (this._proxy.IconThemePath)
+            Gtk.IconTheme.get_default().append_search_path(this._proxy.IconThemePath);
 
         bulkConnect(proxy, [
             ['notify::g-name-owner', () => {

--- a/src/widgets/icon.ts
+++ b/src/widgets/icon.ts
@@ -98,6 +98,7 @@ export default class AgsIcon extends Gtk.Image {
             return;
         const itp = iconThemePath.filter(path => path && path !== '');
         if (itp.length > 0) {
+            print(itp);
             this._iconTheme = Gtk.IconTheme.new();
             this._iconTheme.set_search_path(itp);
         }

--- a/src/widgets/icon.ts
+++ b/src/widgets/icon.ts
@@ -9,32 +9,15 @@ export default class AgsIcon extends Gtk.Image {
         GObject.registerClass({ GTypeName: 'AgsIcon' }, this);
     }
 
-    _iconTheme?: Gtk.IconTheme;
-
     constructor(params: object | string | GdkPixbuf.Pixbuf) {
         const {
             icon = '',
             size = 0,
-            iconThemePath = [],
             ...rest
-        } = params as { icon: string | GdkPixbuf.Pixbuf, size: number,
-            iconThemePath: string[] | string };
+        } = params as { icon: string | GdkPixbuf.Pixbuf, size: number };
         super(typeof params === 'string' || params instanceof GdkPixbuf.Pixbuf ? {} : rest);
 
         this.size = size;
-        if (iconThemePath) {
-            if (typeof iconThemePath === 'string') {
-                this._iconTheme = Gtk.IconTheme.new();
-                this._iconTheme.set_search_path([iconThemePath]);
-            }
-            else {
-                const itp = iconThemePath.filter(path => path && path !== '');
-                if (itp.length > 0) {
-                    this._iconTheme = Gtk.IconTheme.new();
-                    this._iconTheme.set_search_path(itp);
-                }
-            }
-        }
         this.icon = typeof params === 'string' || params instanceof GdkPixbuf.Pixbuf
             ? params : icon;
     }
@@ -61,24 +44,9 @@ export default class AgsIcon extends Gtk.Image {
                 this.set_from_pixbuf(
                     GdkPixbuf.Pixbuf.new_from_file_at_size(icon, this.size, this.size));
             } else {
-                if (this._iconTheme &&
-                    this._iconTheme.lookup_icon(
-                        icon, this.size, Gtk.IconLookupFlags.FORCE_SIZE)) {
-                    this._type = 'pixbuf';
-                    //get the biggest size to avoid upscaling, which results in bad quality,
-                    //alternatively reload icon in draw function.
-                    const sizes = this._iconTheme.get_icon_sizes(icon);
-                    const pixbuf = this._iconTheme.load_icon(
-                        icon, Math.max(...sizes), Gtk.IconLookupFlags.FORCE_SIZE);
-                    // @ts-expect-error
-                    this._icon = pixbuf;
-                    this.set_from_pixbuf(pixbuf);
-                }
-                else {
-                    this._type = 'named';
-                    this.icon_name = icon;
-                    this.pixel_size = this.size;
-                }
+                this._type = 'named';
+                this.icon_name = icon;
+                this.pixel_size = this.size;
             }
         }
         else if (icon instanceof GdkPixbuf.Pixbuf) {
@@ -88,19 +56,6 @@ export default class AgsIcon extends Gtk.Image {
         }
         else {
             logError(new Error(`expected Pixbuf or string for icon, but got ${typeof icon}`));
-        }
-    }
-
-    get iconTheme() { return this._iconTheme?.get_search_path() || []; }
-
-    set iconTheme(iconThemePath: string[]) {
-        if (!iconThemePath || iconThemePath.length === 0)
-            return;
-        const itp = iconThemePath.filter(path => path && path !== '');
-        if (itp.length > 0) {
-            print(itp);
-            this._iconTheme = Gtk.IconTheme.new();
-            this._iconTheme.set_search_path(itp);
         }
     }
 

--- a/src/widgets/icon.ts
+++ b/src/widgets/icon.ts
@@ -98,7 +98,6 @@ export default class AgsIcon extends Gtk.Image {
             return;
         const itp = iconThemePath.filter(path => path && path !== '');
         if (itp.length > 0) {
-            print(itp);
             this._iconTheme = Gtk.IconTheme.new();
             this._iconTheme.set_search_path(itp);
         }

--- a/src/widgets/icon.ts
+++ b/src/widgets/icon.ts
@@ -9,15 +9,32 @@ export default class AgsIcon extends Gtk.Image {
         GObject.registerClass({ GTypeName: 'AgsIcon' }, this);
     }
 
+    _iconTheme?: Gtk.IconTheme;
+
     constructor(params: object | string | GdkPixbuf.Pixbuf) {
         const {
             icon = '',
             size = 0,
+            iconThemePath = [],
             ...rest
-        } = params as { icon: string | GdkPixbuf.Pixbuf, size: number };
+        } = params as { icon: string | GdkPixbuf.Pixbuf, size: number,
+            iconThemePath: string[] | string };
         super(typeof params === 'string' || params instanceof GdkPixbuf.Pixbuf ? {} : rest);
 
         this.size = size;
+        if (iconThemePath) {
+            if (typeof iconThemePath === 'string') {
+                this._iconTheme = Gtk.IconTheme.new();
+                this._iconTheme.set_search_path([iconThemePath]);
+            }
+            else {
+                const itp = iconThemePath.filter(path => path && path !== '');
+                if (itp.length > 0) {
+                    this._iconTheme = Gtk.IconTheme.new();
+                    this._iconTheme.set_search_path(itp);
+                }
+            }
+        }
         this.icon = typeof params === 'string' || params instanceof GdkPixbuf.Pixbuf
             ? params : icon;
     }
@@ -44,9 +61,24 @@ export default class AgsIcon extends Gtk.Image {
                 this.set_from_pixbuf(
                     GdkPixbuf.Pixbuf.new_from_file_at_size(icon, this.size, this.size));
             } else {
-                this._type = 'named';
-                this.icon_name = icon;
-                this.pixel_size = this.size;
+                if (this._iconTheme &&
+                    this._iconTheme.lookup_icon(
+                        icon, this.size, Gtk.IconLookupFlags.FORCE_SIZE)) {
+                    this._type = 'pixbuf';
+                    //get the biggest size to avoid upscaling, which results in bad quality,
+                    //alternatively reload icon in draw function.
+                    const sizes = this._iconTheme.get_icon_sizes(icon);
+                    const pixbuf = this._iconTheme.load_icon(
+                        icon, Math.max(...sizes), Gtk.IconLookupFlags.FORCE_SIZE);
+                    // @ts-expect-error
+                    this._icon = pixbuf;
+                    this.set_from_pixbuf(pixbuf);
+                }
+                else {
+                    this._type = 'named';
+                    this.icon_name = icon;
+                    this.pixel_size = this.size;
+                }
             }
         }
         else if (icon instanceof GdkPixbuf.Pixbuf) {
@@ -56,6 +88,19 @@ export default class AgsIcon extends Gtk.Image {
         }
         else {
             logError(new Error(`expected Pixbuf or string for icon, but got ${typeof icon}`));
+        }
+    }
+
+    get iconTheme() { return this._iconTheme?.get_search_path() || []; }
+
+    set iconTheme(iconThemePath: string[]) {
+        if (!iconThemePath || iconThemePath.length === 0)
+            return;
+        const itp = iconThemePath.filter(path => path && path !== '');
+        if (itp.length > 0) {
+            print(itp);
+            this._iconTheme = Gtk.IconTheme.new();
+            this._iconTheme.set_search_path(itp);
         }
     }
 


### PR DESCRIPTION
If an application uses a custom iconThemePath the icon could not be found and thereby the missing image icon was shown instead. This adds support for custom iconThemePaths.
