### PR TITLE
feat: add hm module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,19 +5,21 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { nixpkgs, self }:
-  let
+  outputs = {
+    nixpkgs,
+    self,
+  }: let
     genSystems = nixpkgs.lib.genAttrs [
       "aarch64-linux"
       "x86_64-linux"
     ];
-    pkgs = genSystems (system: import nixpkgs { inherit system; });
-  in 
-  {
+    pkgs = genSystems (system: import nixpkgs {inherit system;});
+  in {
     packages = genSystems (system: {
       default = pkgs.${system}.callPackage ./nix/ags.nix {
-        gjs = pkgs.${system}.callPackage ./nix/gjs.nix { };
+        gjs = pkgs.${system}.callPackage ./nix/gjs.nix {};
       };
     });
+    homeManagerModules.default = import ./nix/hm-module.nix self;
   };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,37 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  cfg = config.programs.ags;
+  defaultAgsPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in {
+  meta.maintainers = [lib.maintainers.Jappie3];
+
+  options.programs.ags = with lib; {
+    enable = mkEnableOption "ags";
+
+    package = mkOption {
+      type = with types; nullOr package;
+      default = defaultAgsPackage;
+      defaultText = literalExpression "ags.packages.${pkgs.stdenv.hostPlatform.system}.default";
+      description = mkDoc ''
+        The Ags package to use. Defaults to the one provided by the flake.
+      '';
+    };
+
+    configDir = mkOption {
+      type = types.path;
+      example = literalExpression "./ags-config";
+      description = mkDoc ''
+        The directory to symlink to {file}`$XDG_CONFIG_HOME/ags`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+    xdg.configFile."ags".source = cfg.configDir;
+  };
+}


### PR DESCRIPTION
This PR adds a home-manager module for NixOS users which symlinks the path specified in `configDir` to `$XDG_CONFIG_HOME/ags`.

Usage:
```nix
# add the package
home.packages = with pkgs; [
  inputs.ags.packages.${pkgs.system}.default
  # ...
];

# ags config:
imports = [
  inputs.ags.homeManagerModules.default
];
config.programs.ags = {
  enable = true;
  configDir = ./ags-config;
};
```

So you could do something like this:

```
.
├── ags-config
│   └── config.js
└── default.nix
```
