### PR TITLE
add: monitor-change signal to hyprland

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -153,17 +153,17 @@ class HyprlandService extends Service {
                 case 'focusedmon':
                     await this._syncMonitors();
                     break;
-                    
+
                 case 'monitorremoved':
                     await this._syncMonitors();
-                    this.emit('monitor-removed', argv[0])
+                    this.emit('monitor-removed', argv[0]);
                     break;
-                    
+
                 case 'monitoradded':
                     await this._syncMonitors();
-                    this.emit('monitor-added', argv[0])
+                    this.emit('monitor-added', argv[0]);
                     break;
-                    
+
                 case 'createworkspace':
                 case 'destroyworkspace':
                     await this._syncWorkspaces();

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -24,6 +24,8 @@ class HyprlandService extends Service {
             'urgent-window': ['string'],
             'submap': ['string'],
             'keyboard-layout': ['string', 'string'],
+            'monitor-added': ['string'],
+            'monitor-removed': ['string'],
         });
     }
 
@@ -149,11 +151,19 @@ class HyprlandService extends Service {
             switch (e) {
                 case 'workspace':
                 case 'focusedmon':
-                case 'monitorremoved':
-                case 'monitoradded':
                     await this._syncMonitors();
                     break;
-
+                    
+                case 'monitorremoved':
+                    await this._syncMonitors();
+                    this.emit('monitor-removed', argv[0])
+                    break;
+                    
+                case 'monitoradded':
+                    await this._syncMonitors();
+                    this.emit('monitor-added', argv[0])
+                    break;
+                    
                 case 'createworkspace':
                 case 'destroyworkspace':
                     await this._syncWorkspaces();


### PR DESCRIPTION
Hey,

I added the feature to listen only to the Hyprland Service, when the monitor was changed. 

I used it examplary in this implementation to overcome the restriction of GTK3 and wayland to bind a bar to a monitor description.

```typescript

const setMonitorId = (currentPlug: string, win: WindowType) => {
  for (let i = 0; i < Gdk.Display.get_default()!.get_n_monitors(); i++) {
    const plug = Gdk.Display.get_default()?.get_default_screen().get_monitor_plug_name(i)
    if (plug == currentPlug) {
      win.monitor = i
      return i
    }
  }
  return -1
}


export const updateMonitorService  = (monitorSelector: MonitorSelector) => {
  return [Hyprland, (win: WindowType, event: string, plug: string) => {
    console.log(`Monitor ${event} ${plug}`)

     Hyprland.monitors.forEach(monitor => {
    const monitorString = `${monitor.make} ${monitor.model} ${monitor.serial}`
    // strip (<monitor> [via HDMI]) from the string, i.e. via HDMI or others is optional and should not be included, only monitor is relevant
    const monitorPart = monitor.description.split("\(")[1];
    // DP-2 via HDMI) -> DP-2                                            
    // DP-1) -> DP-1
    // DP-1 via HDMI-A-1) -> DP-1      
    const regex = /\w+(?:-\w+)*(?=\s*(?:via\s\w+(?:-\w+)*)?\))/gm;
    const match = monitorPart.match(regex)
    if (match === null) {
      console.error("Found no monitor plug")
      return;
    }
    const monitorPlug = match[0];

    for (const monConfig of monitorSelector) {
      const [monitorName, matchStr]= Object.entries(monConfig)[0] 
      if (monitorString == matchStr) {
        console.log(`Found monitor ${monitorName} with plug ${monitorPlug}`)
        setMonitorId(monitorPlug, win)
      }

    }

  })

}, "monitor-change"] as MonitorService }

```

If you have further comments, I would be happy to add them.