### PR TITLE
Add css property to widgets

### DIFF
--- a/src/widgets/constructor.ts
+++ b/src/widgets/constructor.ts
@@ -18,6 +18,7 @@ interface Connectable extends GObject.Object {
 interface CommonParams {
     className?: string
     style?: string
+    css?: string
     halign?: 'start' | 'center' | 'end' | 'fill'
     valign?: 'start' | 'center' | 'end' | 'fill'
     connections?: (
@@ -31,17 +32,17 @@ interface CommonParams {
 }
 
 function separateCommon({
-    className, style, halign, valign, connections, properties, binds, setup,
+    className, style, css, halign, valign, connections, properties, binds, setup,
     ...rest
 }: CommonParams) {
     return [
-        { className, style, halign, valign, connections, properties, binds, setup },
+        { className, style, css, halign, valign, connections, properties, binds, setup },
         rest,
     ];
 }
 
 function parseCommon(widget: Gtk.Widget, {
-    className, style,
+    className, style, css,
     halign, valign,
     connections = [], properties, binds, setup,
 }: CommonParams) {
@@ -52,6 +53,10 @@ function parseCommon(widget: Gtk.Widget, {
     if (style !== undefined)
         // @ts-expect-error
         widget.style = style;
+
+    if (css !== undefined)
+        // @ts-expect-error
+        widget.css = css;
 
 
     if (typeof halign === 'string') {

--- a/src/widgets/overrides.ts
+++ b/src/widgets/overrides.ts
@@ -66,6 +66,40 @@ Object.defineProperty(Gtk.Widget.prototype, 'style', {
     },
 });
 
+function setCSS(widget: Gtk.Widget, css: string) {
+    if (typeof css !== 'string') {
+        console.error('css has to be a string');
+        return false;
+    }
+
+    const previous = widgetProviders.get(widget);
+    if (previous)
+        widget.get_style_context().remove_provider(previous);
+
+    const provider = new Gtk.CssProvider();
+    widgetProviders.set(widget, provider);
+    provider.load_from_data(`${css}`);
+    widget.get_style_context()
+        .add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
+}
+
+Object.defineProperty(Gtk.Widget.prototype, 'css', {
+    get: function() {
+        return this._css || '';
+    },
+    set: function(css: string) {
+        if (!setCSS(this, css))
+            return;
+
+        this._css = css;
+    },
+});
+
+// @ts-expect-error
+Gtk.Widget.prototype.setCSS = function(css: string) {
+    setCSS(this, css);
+};
+
 // @ts-expect-error
 Gtk.Widget.prototype.setStyle = function(css: string) {
     setStyle(this, css);

--- a/src/widgets/overrides.ts
+++ b/src/widgets/overrides.ts
@@ -37,19 +37,14 @@ Object.defineProperty(Gtk.Widget.prototype, 'className', {
 });
 
 const widgetProviders: Map<Gtk.Widget, Gtk.CssProvider> = new Map();
-function setStyle(widget: Gtk.Widget, css: string) {
-    if (typeof css !== 'string') {
-        console.error('style has to be a string');
-        return false;
-    }
-
+function setCss(widget: Gtk.Widget, css: string) {
     const previous = widgetProviders.get(widget);
     if (previous)
         widget.get_style_context().remove_provider(previous);
 
     const provider = new Gtk.CssProvider();
     widgetProviders.set(widget, provider);
-    provider.load_from_data(`* { ${css} }`);
+    provider.load_from_data(css);
     widget.get_style_context()
         .add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
 }
@@ -59,50 +54,39 @@ Object.defineProperty(Gtk.Widget.prototype, 'style', {
         return this._style || '';
     },
     set: function(css: string) {
-        if (!setStyle(this, css))
+        if (typeof css !== 'string') {
+            console.error('style has to be a string');
             return;
+        }
 
+        setCss(this, `* { ${css} }`);
         this._style = css;
     },
 });
-
-function setCSS(widget: Gtk.Widget, css: string) {
-    if (typeof css !== 'string') {
-        console.error('css has to be a string');
-        return false;
-    }
-
-    const previous = widgetProviders.get(widget);
-    if (previous)
-        widget.get_style_context().remove_provider(previous);
-
-    const provider = new Gtk.CssProvider();
-    widgetProviders.set(widget, provider);
-    provider.load_from_data(`${css}`);
-    widget.get_style_context()
-        .add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
-}
 
 Object.defineProperty(Gtk.Widget.prototype, 'css', {
     get: function() {
         return this._css || '';
     },
     set: function(css: string) {
-        if (!setCSS(this, css))
+        if (typeof css !== 'string') {
+            console.error('css has to be a string');
             return;
+        }
 
+        setCss(this, css);
         this._css = css;
     },
 });
 
 // @ts-expect-error
-Gtk.Widget.prototype.setCSS = function(css: string) {
-    setCSS(this, css);
+Gtk.Widget.prototype.setCss = function(css: string) {
+    setCss(this, css);
 };
 
 // @ts-expect-error
 Gtk.Widget.prototype.setStyle = function(css: string) {
-    setStyle(this, css);
+    setCss(this, `* { ${css} }`);
 };
 
 // @ts-expect-error


### PR DESCRIPTION
This PR is basically a copy of this [commit](https://github.com/elkowar/eww/commit/dc3129aee2806823bdad87785f7ef80651d5245c#diff-3c219209922dee48d8236a78037147e4b91dd51a021089b2749c9e87032bd631) but for AGS instead of EWW.

It allows setting CSS of subnodes such as this scale in EWW:
```lisp
(scale :value song_pos
       :min 0
       :max song_length
       :orientation "h"
       :onchange "playerctl -p Spot position {}"
       :css "highlight { background-color: ${button_accent}; }
             slider { background-color: ${button_accent}; }
             trough { background-color: rgba(${button_accent}, 0.4); }")
```

It would be like this in AGS: 
```javascript
export const PositionSlider = (player, params) => Slider({
    ...params,
    className: 'position-slider',
    css: `highlight { background-color: ${button_accent}; }
          slider { background-color: ${button_accent}; }
          trough { background-color: ${button_accent}; }`,
    hexpand: true,
    drawValue: false,
...
```