### PR TITLE
add submodules to release

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,25 @@
+name: Create Release
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Create tar file
+        run: |
+            cd ..
+            tar -czf "ags-${{ github.ref_name }}.tar.gz" "ags"
+      - name: Upload assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ../ags-${{ github.ref_name }}.tar.gz


### PR DESCRIPTION
This PR adds a github action, which is triggered after a release. It adds an tar file including all git submodules.