### PR TITLE
notify::prop-name signals and bind transform method

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,10 +22,14 @@ plugins:
 rules:
   '@typescript-eslint/ban-ts-comment':
     - 'off'
+
+
   '@typescript-eslint/no-unused-vars':
-    - 'error'
-    - argsIgnonorePattern: '_'
-      varsIgnorePattern: '_'
+    - error
+    # Vars use a suffix _ instead of a prefix because of file-scope private vars
+    - varsIgnorePattern: (^unused|_$)
+      argsIgnorePattern: ^(unused|_)
+
   arrow-parens:
     - error
     - as-needed

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,6 +22,10 @@ plugins:
 rules:
   '@typescript-eslint/ban-ts-comment':
     - 'off'
+  '@typescript-eslint/no-unused-vars':
+    - 'error'
+    - argsIgnonorePattern: '_'
+      varsIgnorePattern: '_'
   arrow-parens:
     - error
     - as-needed

--- a/example/notification-center/config.js
+++ b/example/notification-center/config.js
@@ -1,31 +1,33 @@
-const { Window, Box, Label, EventBox } = ags.Widget;
 import {
     NotificationList, DNDSwitch, ClearButton, PopupList,
 } from './widgets.js';
+import Widget from 'resource:///com/github/Aylur/ags/widget.js';
+import App from 'resource:///com/github/Aylur/ags/app.js';
+import { execAsync, timeout } from 'resource:///com/github/Aylur/ags/utils.js';
 
-const Header = () => Box({
+const Header = () => Widget.Box({
     className: 'header',
     children: [
-        Label('Do Not Disturb'),
+        Widget.Label('Do Not Disturb'),
         DNDSwitch(),
-        Box({ hexpand: true }),
+        Widget.Box({ hexpand: true }),
         ClearButton(),
     ],
 });
 
-const NotificationCenter = () => Window({
+const NotificationCenter = () => Widget.Window({
     name: 'notification-center',
     anchor: 'right top bottom',
     popup: true,
     focusable: true,
-    child: Box({
+    child: Widget.Box({
         children: [
-            EventBox({
+            Widget.EventBox({
                 hexpand: true,
                 connections: [['button-press-event', () =>
-                    ags.App.closeWindow('notification-center')]]
+                    App.closeWindow('notification-center')]]
             }),
-            Box({
+            Widget.Box({
                 vertical: true,
                 children: [
                     Header(),
@@ -36,13 +38,13 @@ const NotificationCenter = () => Window({
     }),
 });
 
-const NotificationsPopupWindow = () => Window({
+const NotificationsPopupWindow = () => Widget.Window({
     name: 'popup-window',
     anchor: 'top',
     child: PopupList(),
 });
 
-ags.Utils.timeout(1000, () => ags.Utils.execAsync([
+timeout(500, () => execAsync([
     'notify-send',
     'Notification Center example',
     'To have the panel popup run "ags toggle-window notification-center"' +
@@ -50,7 +52,7 @@ ags.Utils.timeout(1000, () => ags.Utils.execAsync([
 ]).catch(console.error));
 
 export default {
-    style: ags.App.configDir + '/style.css',
+    style: App.configDir + '/style.css',
     windows: [
         NotificationsPopupWindow(),
         NotificationCenter(),

--- a/example/notification-center/notification.js
+++ b/example/notification-center/notification.js
@@ -1,10 +1,9 @@
-const { Notifications } = ags.Service;
-const { lookUpIcon, timeout } = ags.Utils;
-const { Box, Icon, Label, EventBox, Button } = ags.Widget;
+import Widget from 'resource:///com/github/Aylur/ags/widget.js';
+import { lookUpIcon, timeout } from 'resource:///com/github/Aylur/ags/utils.js';
 
 const NotificationIcon = ({ appEntry, appIcon, image }) => {
     if (image) {
-        return Box({
+        return Widget.Box({
             valign: 'start',
             hexpand: false,
             className: 'icon img',
@@ -26,7 +25,7 @@ const NotificationIcon = ({ appEntry, appIcon, image }) => {
     if (lookUpIcon(appEntry))
         icon = appEntry;
 
-    return Box({
+    return Widget.Box({
         valign: 'start',
         hexpand: false,
         className: 'icon',
@@ -34,7 +33,7 @@ const NotificationIcon = ({ appEntry, appIcon, image }) => {
             min-width: 78px;
             min-height: 78px;
         `,
-        children: [Icon({
+        children: [Widget.Icon({
             icon, size: 58,
             halign: 'center', hexpand: true,
             valign: 'center', vexpand: true,
@@ -42,40 +41,40 @@ const NotificationIcon = ({ appEntry, appIcon, image }) => {
     });
 };
 
-export const Notification = ({ id, summary, body, actions, urgency, ...icon }) => EventBox({
-    className: `notification ${urgency}`,
-    onPrimaryClick: () => Notifications.dismiss(id),
+export const Notification = n => Widget.EventBox({
+    className: `notification ${n.urgency}`,
+    onPrimaryClick: () => n.dismiss(),
     properties: [['hovered', false]],
-    onHover: w => {
-        if (w._hovered)
+    onHover: self => {
+        if (self._hovered)
             return;
 
         // if there are action buttons and they are hovered
         // EventBox onHoverLost will fire off immediately,
         // so to prevent this we delay it
-        timeout(300, () => w._hovered = true);
+        timeout(300, () => self._hovered = true);
     },
-    onHoverLost: w => {
-        if (!w._hovered)
+    onHoverLost: self => {
+        if (!self._hovered)
             return;
 
-        w._hovered = false;
-        Notifications.dismiss(id);
+        self._hovered = false;
+        n.dismiss();
     },
     vexpand: false,
-    child: Box({
+    child: Widget.Box({
         vertical: true,
         children: [
-            Box({
+            Widget.Box({
                 children: [
-                    NotificationIcon(icon),
-                    Box({
+                    NotificationIcon(n),
+                    Widget.Box({
                         hexpand: true,
                         vertical: true,
                         children: [
-                            Box({
+                            Widget.Box({
                                 children: [
-                                    Label({
+                                    Widget.Label({
                                         className: 'title',
                                         xalign: 0,
                                         justification: 'left',
@@ -83,37 +82,37 @@ export const Notification = ({ id, summary, body, actions, urgency, ...icon }) =
                                         maxWidthChars: 24,
                                         truncate: 'end',
                                         wrap: true,
-                                        label: summary,
-                                        useMarkup: summary.startsWith('<'),
+                                        label: n.summary,
+                                        useMarkup: true,
                                     }),
-                                    Button({
+                                    Widget.Button({
                                         className: 'close-button',
                                         valign: 'start',
-                                        child: Icon('window-close-symbolic'),
-                                        onClicked: () => Notifications.close(id),
+                                        child: Widget.Icon('window-close-symbolic'),
+                                        onClicked: n.close.bind(n),
                                     }),
                                 ],
                             }),
-                            Label({
+                            Widget.Label({
                                 className: 'description',
                                 hexpand: true,
                                 useMarkup: true,
                                 xalign: 0,
                                 justification: 'left',
-                                label: body,
+                                label: n.body,
                                 wrap: true,
                             }),
                         ],
                     }),
                 ],
             }),
-            Box({
+            Widget.Box({
                 className: 'actions',
-                children: actions.map(action => Button({
+                children: n.actions.map(({ id, label }) => Button({
                     className: 'action-button',
-                    onClicked: () => Notifications.invoke(id, action.id),
+                    onClicked: () => n.invoke(id),
                     hexpand: true,
-                    child: Label(action.label),
+                    child: Widget.Label(label),
                 })),
             }),
         ],

--- a/example/notification-center/widgets.js
+++ b/example/notification-center/widgets.js
@@ -1,40 +1,38 @@
 import { Notification } from './notification.js';
-const { Gtk } = imports.gi;
-const { Notifications } = ags.Service;
-const { Scrollable, Box, Icon, Label, Widget, Button, Stack } = ags.Widget;
+import Notifications from 'resource:///com/github/Aylur/ags/service/notifications.js';
+import Gtk from 'gi://Gtk';
+import Widget from 'resource:///com/github/Aylur/ags/widget.js';
 
-const List = () => Box({
+const List = () => Widget.Box({
     vertical: true,
     vexpand: true,
-    connections: [[Notifications, box => {
-        box.children = Notifications.notifications
+    connections: [[Notifications, self => {
+        self.children = Notifications.notifications
             .reverse()
-            .map(n => Notification(n));
+            .map(Notification);
 
-        box.visible = Notifications.notifications.length > 0;
+        self.visible = Notifications.notifications.length > 0;
     }]],
 });
 
-const Placeholder = () => Box({
+const Placeholder = () => Widget.Box({
     className: 'placeholder',
     vertical: true,
     vexpand: true,
     valign: 'center',
     children: [
-        Icon('notifications-disabled-symbolic'),
-        Label('Your inbox is empty'),
+        Widget.Icon('notifications-disabled-symbolic'),
+        Widget.Label('Your inbox is empty'),
     ],
-    connections: [
-        [Notifications, box => {
-            box.visible = Notifications.notifications.length === 0;
-        }],
+    binds: [
+        ['visible', Notifications, 'notifications', n => n.length === 0],
     ],
 });
 
-export const NotificationList = () => Scrollable({
+export const NotificationList = () => Widget.Scrollable({
     hscroll: 'never',
     vscroll: 'automatic',
-    child: Box({
+    child: Widget.Box({
         className: 'list',
         vertical: true,
         children: [
@@ -44,22 +42,19 @@ export const NotificationList = () => Scrollable({
     }),
 });
 
-export const ClearButton = () => Button({
-    onClicked: Notifications.clear,
-    connections: [[Notifications, button => {
-        button.sensitive = Notifications.notifications.length > 0;
-    }]],
-    child: Box({
+export const ClearButton = () => Widget.Button({
+    onClicked: () => Notifications.clear(),
+    binds: [
+        ['sensitive', Notifications, 'notifications', n => n.length > 0],
+    ],
+    child: Widget.Box({
         children: [
-            Label('Clear'),
-            Stack({
-                items: [
-                    ['true', Icon('user-trash-full-symbolic')],
-                    ['false', Icon('user-trash-symbolic')],
+            Widget.Label('Clear'),
+            Widget.Icon({
+                binds: [
+                    ['icon', Notifications, 'notifications', n =>
+                        `user-trash-${n.length > 0 ? 'full-' : ''}symbolic`],
                 ],
-                connections: [[Notifications, stack => {
-                    stack.shown = `${Notifications.notifications.length > 0}`;
-                }]],
             }),
         ],
     }),
@@ -68,19 +63,15 @@ export const ClearButton = () => Button({
 export const DNDSwitch = () => Widget({
     type: Gtk.Switch,
     valign: 'center',
-    connections: [
-        ['notify::active', ({ active }) => {
-            Notifications.dnd = active;
-        }],
-    ],
+    connections: [['notify::active', ({ active }) => {
+        Notifications.dnd = active;
+    }]],
 });
 
-export const PopupList = () => Box({
+export const PopupList = () => Widget.Box({
     className: 'list',
     style: 'padding: 1px;', // so it shows up
     vertical: true,
-    connections: [[Notifications, box => {
-        box.children = Array.from(Notifications.popups.values())
-            .map(n => Notification(n));
-    }]],
+    binds: [['children', Notifications, 'popups',
+        popups => popups.map(Notification)]],
 });

--- a/src/service/applications.ts
+++ b/src/service/applications.ts
@@ -69,7 +69,12 @@ class Application extends Service {
 }
 
 class ApplicationsService extends Service {
-    static { Service.register(this); }
+    static {
+        Service.register(this, {}, {
+            'list': ['jsobject'],
+            'frequents': ['jsobject'],
+        });
+    }
 
     private _list!: Application[];
     private _frequents: { [app: string]: number };
@@ -94,7 +99,7 @@ class ApplicationsService extends Service {
         this._sync();
     }
 
-    get list() { return [...this._list]; }
+    get list() { return this._list; }
     get frequents() { return this._frequents; }
 
     private _launched(id: string | null) {
@@ -108,6 +113,8 @@ class ApplicationsService extends Service {
         ensureDirectory(APPS_CACHE_DIR);
         const json = JSON.stringify(this._frequents, null, 2);
         writeFile(json, CACHE_FILE).catch(logError);
+        this.notify('frequents');
+        this.emit('changed');
     }
 
     private _sync() {
@@ -121,6 +128,7 @@ class ApplicationsService extends Service {
             this._launched(app.desktop);
         }));
 
+        this.notify('list');
         this.emit('changed');
     }
 }

--- a/src/service/applications.ts
+++ b/src/service/applications.ts
@@ -21,44 +21,22 @@ class Application extends Service {
         });
     }
 
-    app: Gio.DesktopAppInfo;
-    frequency: number;
-    name: string;
-    desktop: string | null;
-    description: string | null;
-    wmClass: string | null;
-    executable: string;
-    iconName: string;
-    service: ApplicationsService;
+    _app: Gio.DesktopAppInfo;
+    _frequency: number;
 
-    // for binds compatibility
-    get icon_name() { return this.iconName; }
-    get wm_class() { return this.wmClass; }
+    get app() { return this._app; }
+    get frequency() { return this._frequency; }
+    get name() { return this._app.get_name(); }
+    get desktop() { return this._app.get_id(); }
+    get description() { return this._app.get_description(); }
+    get wm_class() { return this._app.get_startup_wm_class(); }
+    get executable() { return this._app.get_executable(); }
+    get icon_name() { return this._app.get_string('Icon'); }
 
-    constructor(app: Gio.DesktopAppInfo, service: ApplicationsService) {
+    constructor(app: Gio.DesktopAppInfo, frequency: number) {
         super();
-        this.service = service;
-        this.app = app;
-        this.name = app.get_name();
-        this.desktop = app.get_id();
-        this.executable = app.get_executable();
-        this.description = app.get_description();
-        this.iconName = this._iconName(app);
-        this.wmClass = app.get_startup_wm_class();
-        this.frequency = this.desktop && service.frequents[this.desktop] || 0;
-    }
-
-    private _iconName(app: Gio.DesktopAppInfo): string {
-        if (!app.get_icon())
-            return '';
-
-        // @ts-expect-error
-        if (typeof app.get_icon()?.get_names !== 'function')
-            return '';
-
-        // @ts-expect-error
-        const name = app.get_icon()?.get_names()[0];
-        return name || '';
+        this._app = app;
+        this._frequency = frequency;
     }
 
     private _match(prop: string | null, search: string) {
@@ -71,6 +49,10 @@ class Application extends Service {
         return prop?.toLowerCase().includes(search.toLowerCase());
     }
 
+    getKey(key: string) {
+        return this._app.get_string(key);
+    }
+
     match(term: string) {
         const { name, desktop, description, executable } = this;
         return this._match(name, term) ||
@@ -80,7 +62,7 @@ class Application extends Service {
     }
 
     launch() {
-        this.frequency++;
+        this._frequency++;
         this.app.launch([], null);
         this.emit('launched');
     }
@@ -133,7 +115,7 @@ class ApplicationsService extends Service {
             .filter(app => app.should_show())
             .map(app => Gio.DesktopAppInfo.new(app.get_id() || ''))
             .filter(app => app)
-            .map(app => new Application(app, this));
+            .map(app => new Application(app, this.frequents[app.get_id() || ''] || 0));
 
         this._list.forEach(app => app.connect('launched', () => {
             this._launched(app.desktop);

--- a/src/service/applications.ts
+++ b/src/service/applications.ts
@@ -7,7 +7,18 @@ const CACHE_FILE = APPS_CACHE_DIR + '/apps_frequency.json';
 
 class Application extends Service {
     static {
-        Service.register(this, { 'launched': [] });
+        Service.register(this, {
+            'launched': [],
+        }, {
+            'app': ['jsobject'],
+            'frequency': ['int'],
+            'name': ['string'],
+            'desktop': ['jsobject'],
+            'description': ['jsobject'],
+            'wm-class': ['jsobject'],
+            'executable': ['string'],
+            'icon-name': ['string'],
+        });
     }
 
     app: Gio.DesktopAppInfo;
@@ -19,6 +30,10 @@ class Application extends Service {
     executable: string;
     iconName: string;
     service: ApplicationsService;
+
+    // for binds compatibility
+    get icon_name() { return this.iconName; }
+    get wm_class() { return this.wmClass; }
 
     constructor(app: Gio.DesktopAppInfo, service: ApplicationsService) {
         super();
@@ -72,11 +87,7 @@ class Application extends Service {
 }
 
 class ApplicationsService extends Service {
-    static {
-        Service.register(this, {
-            'launched': ['string'],
-        });
-    }
+    static { Service.register(this); }
 
     private _list!: Application[];
     private _frequents: { [app: string]: number };

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -29,8 +29,6 @@ class Stream extends Service {
     private _ids: number[];
     private _oldVolume = 0;
 
-    get stream() { return this._stream; }
-
     constructor(stream: Gvc.MixerStream) {
         super();
 
@@ -47,6 +45,7 @@ class Stream extends Service {
         }));
     }
 
+    get stream() { return this._stream; }
     get description() { return this._stream.description; }
     get icon_name() { return this._stream.icon_name; }
     get id() { return this._stream.id; }
@@ -60,7 +59,7 @@ class Stream extends Service {
             this.volume = 0;
         }
         else if (this.volume === 0) {
-            this.volume = this._oldVolume;
+            this.volume = this._oldVolume || 0.25;
         }
     }
 
@@ -95,6 +94,9 @@ class AudioService extends Service {
             'stream-added': ['int'],
             'stream-removed': ['int'],
         }, {
+            'apps': ['jsobject', 'rw'],
+            'speakers': ['jsobject', 'rw'],
+            'microphones': ['jsobject', 'rw'],
             'speaker': ['jsobject', 'rw'],
             'microphone': ['jsobject', 'rw'],
         });
@@ -172,6 +174,16 @@ class AudioService extends Service {
 
         this._streams.set(id, stream);
         this._streamBindings.set(id, binding);
+
+        if (gvcstream instanceof Gvc.MixerSource)
+            this.notify('microphones');
+
+        if (gvcstream instanceof Gvc.MixerSink)
+            this.notify('speakers');
+
+        if (gvcstream instanceof Gvc.MixerSinkInput)
+            this.notify('apps');
+
         this.emit('stream-added', id);
         this.emit('changed');
     }
@@ -187,6 +199,16 @@ class AudioService extends Service {
         this._streams.delete(id);
         this._streamBindings.delete(id);
         this.emit('stream-removed', id);
+
+        if (stream.stream instanceof Gvc.MixerSource)
+            this.notify('microphones');
+
+        if (stream.stream instanceof Gvc.MixerSink)
+            this.notify('speakers');
+
+        if (stream.stream instanceof Gvc.MixerSinkInput)
+            this.notify('apps');
+
         this.emit('changed');
     }
 

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -42,11 +42,8 @@ class Stream extends Service {
             'id',
             'state',
         ].map(prop => stream.connect(`notify::${prop}`, () => {
-            this.notify(prop);
-            this.emit('changed');
+            this.changed(prop);
         }));
-
-        this.emit('changed');
     }
 
     get description() { return this._stream.description; }
@@ -121,13 +118,6 @@ class AudioService extends Service {
             ['stream-removed', this._streamRemoved.bind(this)],
         ]);
 
-        bulkConnect(this, [
-            ['speaker-changed', () => this.emit('changed')],
-            ['microphone-changed', () => this.emit('changed')],
-            ['stream-added', () => this.emit('changed')],
-            ['stream-added', () => this.emit('changed')],
-        ]);
-
         this._control.open();
     }
 
@@ -161,7 +151,7 @@ class AudioService extends Service {
 
         this[`_${type}Binding`] = stream.connect('changed', () => this.emit(`${type}-changed`));
         this[`_${type}`] = stream;
-        this.notify(type);
+        this.changed(type);
         this.emit(`${type}-changed`);
     }
 
@@ -176,6 +166,7 @@ class AudioService extends Service {
         this._streams.set(id, stream);
         this._streamBindings.set(id, binding);
         this.emit('stream-added', id);
+        this.emit('changed');
     }
 
     private _streamRemoved(_c: Gvc.MixerControl, id: number) {
@@ -189,6 +180,7 @@ class AudioService extends Service {
         this._streams.delete(id);
         this._streamBindings.delete(id);
         this.emit('stream-removed', id);
+        this.emit('changed');
     }
 
     private _getStreams(filter: { new(): Gvc.MixerStream }) {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -27,6 +27,7 @@ class Stream extends Service {
 
     private _stream: Gvc.MixerStream;
     private _ids: number[];
+    private _oldVolume = 0;
 
     get stream() { return this._stream; }
 
@@ -47,15 +48,21 @@ class Stream extends Service {
     }
 
     get description() { return this._stream.description; }
-    get iconName() { return this._stream.icon_name; }
+    get icon_name() { return this._stream.icon_name; }
     get id() { return this._stream.id; }
     get name() { return this._stream.name; }
     get state() { return _MIXER_CONTROL_STATE[this._stream.state]; }
-    get isMuted() { return this._stream.is_muted; }
 
-    // for binds compatibility
-    get icon_name() { return this.iconName; }
-    get is_muted() { return this.isMuted; }
+    get is_muted() { return this.volume === 0; }
+    set is_muted(mute: boolean) {
+        if (mute) {
+            this._oldVolume = this.volume;
+            this.volume = 0;
+        }
+        else if (this.volume === 0) {
+            this.volume = this._oldVolume;
+        }
+    }
 
     get volume() {
         const max = Audio.instance.control.get_vol_max_norm();

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -4,10 +4,24 @@ import Gvc from 'gi://Gvc';
 import App from '../app.js';
 import { bulkConnect, bulkDisconnect } from '../utils.js';
 
+const _MIXER_CONTROL_STATE = {
+    [Gvc.MixerControlState.CLOSED]: 'closed',
+    [Gvc.MixerControlState.READY]: 'ready',
+    [Gvc.MixerControlState.CONNECTING]: 'connecting',
+    [Gvc.MixerControlState.FAILED]: 'failed',
+};
+
 class Stream extends Service {
     static {
         Service.register(this, {
             'closed': [],
+        }, {
+            'description': ['string'],
+            'is-muted': ['boolean'],
+            'volume': ['float', 'rw'],
+            'icon-name': ['string'],
+            'id': ['int'],
+            'state': ['string'],
         });
     }
 
@@ -27,9 +41,10 @@ class Stream extends Service {
             'icon-name',
             'id',
             'state',
-        ].map(prop => stream.connect(
-            `notify::${prop}`, () => this.emit('changed'),
-        ));
+        ].map(prop => stream.connect(`notify::${prop}`, () => {
+            this.notify(prop);
+            this.emit('changed');
+        }));
 
         this.emit('changed');
     }
@@ -38,9 +53,12 @@ class Stream extends Service {
     get iconName() { return this._stream.icon_name; }
     get id() { return this._stream.id; }
     get name() { return this._stream.name; }
-
-    set isMuted(muted) { this._stream.set_is_muted(muted); }
+    get state() { return _MIXER_CONTROL_STATE[this._stream.state]; }
     get isMuted() { return this._stream.is_muted; }
+
+    // for binds compatibility
+    get icon_name() { return this.iconName; }
+    get is_muted() { return this.isMuted; }
 
     get volume() {
         const max = Audio.instance.control.get_vol_max_norm();
@@ -72,27 +90,29 @@ class AudioService extends Service {
             'microphone-changed': [],
             'stream-added': ['int'],
             'stream-removed': ['int'],
+        }, {
+            'speaker': ['jsobject', 'rw'],
+            'microphone': ['jsobject', 'rw'],
         });
     }
 
     private _control: Gvc.MixerControl;
     private _streams: Map<number, Stream>;
+    private _streamBindings: Map<number, number>;
     private _speaker!: Stream;
     private _microphone!: Stream;
     private _speakerBinding!: number;
     private _microphoneBinding!: number;
 
-    get speaker() { return this._speaker; }
-    get microphone() { return this._microphone; }
-
-    get control() { return this._control; }
-
     constructor() {
         super();
+
         this._control = new Gvc.MixerControl({
             name: `${pkg.name} mixer control`,
         });
+
         this._streams = new Map();
+        this._streamBindings = new Map();
 
         bulkConnect((this._control as unknown) as GObject.Object, [
             ['default-sink-changed', (_c, id: number) => this._defaultChanged(id, 'speaker')],
@@ -101,7 +121,34 @@ class AudioService extends Service {
             ['stream-removed', this._streamRemoved.bind(this)],
         ]);
 
+        bulkConnect(this, [
+            ['speaker-changed', () => this.emit('changed')],
+            ['microphone-changed', () => this.emit('changed')],
+            ['stream-added', () => this.emit('changed')],
+            ['stream-added', () => this.emit('changed')],
+        ]);
+
         this._control.open();
+    }
+
+    get control() { return this._control; }
+
+    get speaker() { return this._speaker; }
+    set speaker(stream: Stream) {
+        this._control.set_default_sink(stream.stream);
+    }
+
+    get microphone() { return this._microphone; }
+    set microphone(stream: Stream) {
+        this._control.set_default_source(stream.stream);
+    }
+
+    get microphones() { return this._getStreams(Gvc.MixerSource); }
+    get speakers() { return this._getStreams(Gvc.MixerSink); }
+    get apps() { return this._getStreams(Gvc.MixerSinkInput); }
+
+    getStream(id: number) {
+        return this._streams.get(id);
     }
 
     private _defaultChanged(id: number, type: 'speaker' | 'microphone') {
@@ -112,49 +159,39 @@ class AudioService extends Service {
         if (!stream)
             return;
 
-        this[`_${type}Binding`] = stream.connect(
-            'changed',
-            () => this.emit(`${type}-changed`),
-        );
+        this[`_${type}Binding`] = stream.connect('changed', () => this.emit(`${type}-changed`));
         this[`_${type}`] = stream;
+        this.notify(type);
         this.emit(`${type}-changed`);
-        this.emit('changed');
     }
 
     private _streamAdded(_c: Gvc.MixerControl, id: number) {
         if (this._streams.has(id))
             return;
 
-        const stream = this._control.lookup_stream_id(id);
+        const gvcstream = this._control.lookup_stream_id(id);
+        const stream = new Stream(gvcstream);
+        const binding = stream.connect('changed', () => this.emit('changed'));
 
-        this._streams.set(id, new Stream(stream));
-        this.emit('changed');
+        this._streams.set(id, stream);
+        this._streamBindings.set(id, binding);
         this.emit('stream-added', id);
     }
 
     private _streamRemoved(_c: Gvc.MixerControl, id: number) {
-        if (!this._streams.has(id))
+        const stream = this._streams.get(id);
+        if (!stream)
             return;
 
-        this._streams.get(id)?.close();
+        stream.disconnect(this._streamBindings.get(id) as number);
+        stream.close();
+
         this._streams.delete(id);
-        this.emit('changed');
+        this._streamBindings.delete(id);
         this.emit('stream-removed', id);
     }
 
-    setSpeaker(stream: Stream) {
-        this._control.set_default_sink(stream.stream);
-    }
-
-    setMicrophone(stream: Stream) {
-        this._control.set_default_source(stream.stream);
-    }
-
-    getStream(id: number) {
-        return this._streams.get(id);
-    }
-
-    getStreams(filter: { new(): Gvc.MixerStream }) {
+    private _getStreams(filter: { new(): Gvc.MixerStream }) {
         const list = [];
         for (const [, stream] of this._streams) {
             if (stream.stream instanceof filter)
@@ -174,13 +211,13 @@ export default class Audio {
 
     static getStream(id: number) { return Audio.instance.getStream(id); }
 
-    static get microphones() { return Audio.instance.getStreams(Gvc.MixerSource); }
-    static get speakers() { return Audio.instance.getStreams(Gvc.MixerSink); }
-    static get apps() { return Audio.instance.getStreams(Gvc.MixerSinkInput); }
+    static get microphones() { return Audio.instance.microphones; }
+    static get speakers() { return Audio.instance.speakers; }
+    static get apps() { return Audio.instance.apps; }
 
     static get microphone() { return Audio.instance.microphone; }
-    static set microphone(stream: Stream) { Audio.instance.setMicrophone(stream); }
+    static set microphone(stream: Stream) { Audio.instance.microphone = stream; }
 
     static get speaker() { return Audio.instance.speaker; }
-    static set speaker(stream: Stream) { Audio.instance.setSpeaker(stream); }
+    static set speaker(stream: Stream) { Audio.instance.speaker = stream; }
 }

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -28,11 +28,17 @@ class BatteryService extends Service {
 
     private _proxy: BatteryProxy;
 
-    available = false;
-    percent = -1;
-    charging = false;
-    charged = false;
-    icon_name = 'battery-missing-symbolic';
+    private _available = false;
+    private _percent = -1;
+    private _charging = false;
+    private _charged = false;
+    private _iconName = 'battery-missing-symbolic';
+
+    get available() { return this._available; }
+    get percent() { return this._percent; }
+    get charging() { return this._charging; }
+    get charged() { return this._charged; }
+    get icon_name() { return this._iconName; }
 
     constructor() {
         super();
@@ -61,14 +67,14 @@ class BatteryService extends Service {
 
         const level = Math.floor(percent / 10) * 10;
 
-        this.icon_name = charged
+        this._iconName = charged
             ? 'battery-level-100-charged-symbolic'
             : `battery-level-${level}${state}-symbolic`;
 
-        this.charging = this._proxy.State === DeviceState.CHARGING;
-        this.percent = percent;
-        this.charged = charged;
-        this.available = true;
+        this._charging = this._proxy.State === DeviceState.CHARGING;
+        this._percent = percent;
+        this._charged = charged;
+        this._available = true;
 
         ['available', 'icon-name', 'percent', 'charging', 'charged']
             .map(prop => this.notify(prop));
@@ -89,6 +95,8 @@ export default class Battery {
     static get percent() { return Battery.instance.percent; }
     static get charging() { return Battery.instance.charging; }
     static get charged() { return Battery.instance.charged; }
+
     static get iconName() { return Battery.instance.icon_name; }
     static get icon_name() { return Battery.instance.icon_name; }
+    static get ['icon-name']() { return Battery.instance.icon_name; }
 }

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -55,7 +55,7 @@ class BatteryService extends Service {
 
     private _sync() {
         if (!this._proxy.IsPresent)
-            return;
+            return this.updateProperty('available', false);
 
         const charging = this._proxy.State === DeviceState.CHARGING;
         const percent = this._proxy.Percentage;

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -57,28 +57,25 @@ class BatteryService extends Service {
         if (!this._proxy.IsPresent)
             return;
 
+        const charging = this._proxy.State === DeviceState.CHARGING;
         const percent = this._proxy.Percentage;
         const charged =
             this._proxy.State === DeviceState.FULLY_CHARGED ||
             (this._proxy.State === DeviceState.CHARGING && percent === 100);
 
+        const level = Math.floor(percent / 10) * 10;
         const state = this._proxy.State ===
             DeviceState.CHARGING ? '-charging' : '';
 
-        const level = Math.floor(percent / 10) * 10;
-
-        this._iconName = charged
+        const iconName = charged
             ? 'battery-level-100-charged-symbolic'
             : `battery-level-${level}${state}-symbolic`;
 
-        this._charging = this._proxy.State === DeviceState.CHARGING;
-        this._percent = percent;
-        this._charged = charged;
-        this._available = true;
-
-        ['available', 'icon-name', 'percent', 'charging', 'charged']
-            .map(prop => this.notify(prop));
-
+        this.updateProperty('available', true);
+        this.updateProperty('icon-name', iconName);
+        this.updateProperty('percent', percent);
+        this.updateProperty('charging', charging);
+        this.updateProperty('charged', charged);
         this.emit('changed');
     }
 }

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -14,15 +14,28 @@ const DeviceState = {
 };
 
 class BatteryService extends Service {
-    static { Service.register(this); }
+    static {
+        Service.register(this, {
+            'closed': [],
+        }, {
+            'available': ['boolean'],
+            'percent': ['int'],
+            'charging': ['boolean'],
+            'charged': ['boolean'],
+            'icon-name': ['string'],
+        });
+    }
+
+    private _proxy: BatteryProxy;
 
     available = false;
     percent = -1;
     charging = false;
     charged = false;
     iconName = 'battery-missing-symbolic';
-    private _proxy: BatteryProxy;
 
+    // for binds compatibility
+    get icon_name() { return this.iconName; }
 
     constructor() {
         super();
@@ -50,6 +63,7 @@ class BatteryService extends Service {
             DeviceState.CHARGING ? '-charging' : '';
 
         const level = Math.floor(percent / 10) * 10;
+
         this.iconName = charged
             ? 'battery-level-100-charged-symbolic'
             : `battery-level-${level}${state}-symbolic`;
@@ -58,6 +72,12 @@ class BatteryService extends Service {
         this.percent = percent;
         this.charged = charged;
         this.available = true;
+
+        this.notify('available');
+        this.notify('icon-name');
+        this.notify('percent');
+        this.notify('charging');
+        this.notify('charged');
 
         this.emit('changed');
     }
@@ -76,4 +96,5 @@ export default class Battery {
     static get charging() { return Battery.instance.charging; }
     static get charged() { return Battery.instance.charged; }
     static get iconName() { return Battery.instance.iconName; }
+    static get icon_name() { return Battery.instance.icon_name; }
 }

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -32,10 +32,7 @@ class BatteryService extends Service {
     percent = -1;
     charging = false;
     charged = false;
-    iconName = 'battery-missing-symbolic';
-
-    // for binds compatibility
-    get icon_name() { return this.iconName; }
+    icon_name = 'battery-missing-symbolic';
 
     constructor() {
         super();
@@ -64,7 +61,7 @@ class BatteryService extends Service {
 
         const level = Math.floor(percent / 10) * 10;
 
-        this.iconName = charged
+        this.icon_name = charged
             ? 'battery-level-100-charged-symbolic'
             : `battery-level-${level}${state}-symbolic`;
 
@@ -92,6 +89,6 @@ export default class Battery {
     static get percent() { return Battery.instance.percent; }
     static get charging() { return Battery.instance.charging; }
     static get charged() { return Battery.instance.charged; }
-    static get iconName() { return Battery.instance.iconName; }
+    static get iconName() { return Battery.instance.icon_name; }
     static get icon_name() { return Battery.instance.icon_name; }
 }

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -73,11 +73,8 @@ class BatteryService extends Service {
         this.charged = charged;
         this.available = true;
 
-        this.notify('available');
-        this.notify('icon-name');
-        this.notify('percent');
-        this.notify('charging');
-        this.notify('charged');
+        ['available', 'icon-name', 'percent', 'charging', 'charged']
+            .map(prop => this.notify(prop));
 
         this.emit('changed');
     }

--- a/src/service/bluetooth.ts
+++ b/src/service/bluetooth.ts
@@ -66,20 +66,15 @@ class BluetoothDevice extends Service {
 
     get address() { return this._device.address; }
     get alias() { return this._device.alias; }
-    get batteryLevel() { return this._device.battery_level; }
-    get batteryPercentage() { return this._device.battery_percentage; }
+    get battery_level() { return this._device.battery_level; }
+    get battery_percentage() { return this._device.battery_percentage; }
     get connected() { return this._device.connected; }
-    get iconName() { return this._device.icon; }
+    get icon_name() { return this._device.icon; }
     get name() { return this._device.name; }
     get paired() { return this._device.paired; }
     get trusted() { return this._device.trusted; }
     get type() { return GnomeBluetooth.type_to_string(this._device.type); }
     get connecting() { return this._connecting || false; }
-
-    // for binds compatibility
-    get battery_level() { return this.batteryLevel; }
-    get battery_percentage() { return this.batteryPercentage; }
-    get icon_name() { return this.iconName; }
 
     setConnection(connect: boolean) {
         this._connecting = true;
@@ -190,7 +185,7 @@ class BluetoothService extends Service {
     get state() { return _ADAPTER_STATE[this._client.default_adapter_state]; }
 
     get devices() { return Array.from(this._devices.values()); }
-    get connectedDevices() {
+    get connected_devices() {
         const list = [];
         for (const [, device] of this._devices) {
             if (device.connected)
@@ -198,8 +193,6 @@ class BluetoothService extends Service {
         }
         return list;
     }
-
-    get connected_devices() { return this.connectedDevices; }
 }
 
 export default class Bluetooth {
@@ -213,7 +206,7 @@ export default class Bluetooth {
     static getDevice(address: string) { return Bluetooth.instance.getDevice(address); }
 
     static get devices() { return Bluetooth.instance.devices; }
-    static get connectedDevices() { return Bluetooth.instance.connectedDevices; }
+    static get connectedDevices() { return Bluetooth.instance.connected_devices; }
     static get connected_devices() { return Bluetooth.instance.connected_devices; }
     static get enabled() { return Bluetooth.instance.enabled; }
     static set enabled(enable: boolean) { Bluetooth.instance.enabled = enable; }

--- a/src/service/bluetooth.ts
+++ b/src/service/bluetooth.ts
@@ -168,7 +168,7 @@ class BluetoothService extends Service {
                 try {
                     const s = client.connect_service_finish(res);
                     callback(s);
-                    this.notify('connected-devices');
+                    this.changed('connected-devices');
                 } catch (error) {
                     logError(error as Error);
                     callback(false);
@@ -205,10 +205,11 @@ export default class Bluetooth {
 
     static getDevice(address: string) { return Bluetooth.instance.getDevice(address); }
 
-    static get devices() { return Bluetooth.instance.devices; }
-    static get connectedDevices() { return Bluetooth.instance.connected_devices; }
-    static get connected_devices() { return Bluetooth.instance.connected_devices; }
     static get enabled() { return Bluetooth.instance.enabled; }
     static set enabled(enable: boolean) { Bluetooth.instance.enabled = enable; }
     static get state() { return Bluetooth.instance.state; }
+    static get devices() { return Bluetooth.instance.devices; }
+    static get connectedDevices() { return Bluetooth.instance.connected_devices; }
+    static get connected_devices() { return Bluetooth.instance.connected_devices; }
+    static get ['connected-devices']() { return Bluetooth.instance.connected_devices; }
 }

--- a/src/service/bluetooth.ts
+++ b/src/service/bluetooth.ts
@@ -151,7 +151,9 @@ class BluetoothService extends Service {
 
         this._devices.get(device.address)?.close();
         this._devices.delete(device.address);
-        this.changed('devices');
+        this.notify('devices');
+        this.notify('connected-devices');
+        this.emit('changed');
     }
 
     connectDevice(

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -21,11 +21,6 @@ class ActiveClient extends Service {
     get address() { return this._address; }
     get title() { return this._title; }
     get class() { return this._class; }
-
-    _set(attr: 'address' | 'title' | 'class', value: string) {
-        this[`_${attr}`] = value;
-        this.changed(attr);
-    }
 }
 
 class ActiveWorkspace extends Service {
@@ -41,16 +36,6 @@ class ActiveWorkspace extends Service {
 
     get id() { return this._id; }
     get name() { return this._name; }
-
-    _set(attr: 'id' | 'name', value: unknown) {
-        if (attr === 'id')
-            this._id = value as number;
-
-        if (attr === 'name')
-            this._name = value as string;
-
-        this.changed(attr);
-    }
 }
 
 class Actives extends Service {
@@ -82,11 +67,6 @@ class Actives extends Service {
     get client() { return this._client; }
     get monitor() { return this._monitor; }
     get workspace() { return this._workspace; }
-
-    _setMonitor(mon: string) {
-        this._monitor = mon;
-        this.changed('monitor');
-    }
 }
 
 class HyprlandService extends Service {
@@ -180,9 +160,9 @@ class HyprlandService extends Service {
             json.forEach(monitor => {
                 this._monitors.set(monitor.id, monitor);
                 if (monitor.focused) {
-                    this._active._setMonitor(monitor.name);
-                    this._active.workspace._set('id', monitor.activeWorkspace.id);
-                    this._active.workspace._set('name', monitor.activeWorkspace.name);
+                    this._active.updateProperty('monitor', monitor.name);
+                    this._active.workspace.updateProperty('id', monitor.activeWorkspace.id);
+                    this._active.workspace.updateProperty('name', monitor.activeWorkspace.name);
                 }
             });
             this.notify('monitors');
@@ -271,18 +251,18 @@ class HyprlandService extends Service {
                     break;
 
                 case 'activewindow':
-                    this._active.client._set('class', argv[0]);
-                    this._active.client._set('title', argv.slice(1).join(','));
+                    this._active.client.updateProperty('class', argv[0]);
+                    this._active.client.updateProperty('title', argv.slice(1).join(','));
                     break;
 
                 case 'activewindowv2':
-                    this._active.client._set('address', '0x' + argv[0]);
+                    this._active.client.updateProperty('address', '0x' + argv[0]);
                     break;
 
                 case 'closewindow':
-                    this._active.client._set('class', '');
-                    this._active.client._set('title', '');
-                    this._active.client._set('address', '');
+                    this._active.client.updateProperty('class', '');
+                    this._active.client.updateProperty('title', '');
+                    this._active.client.updateProperty('address', '');
                     await this._syncClients();
                     await this._syncWorkspaces();
                     this.emit('client-removed', '0x' + argv[0]);

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -335,7 +335,10 @@ export default class Hyprland {
     static get clients() { return Hyprland.instance.clients; }
     static get active() { return Hyprland.instance.active; }
 
-    static hyprctlGet(cmd: string): unknown | object {
+    static HyprctlGet(cmd: string): unknown | object {
+        console.error('Hyprland.HyprctlGet is DEPRECATED' +
+            "use JSON.parse(Utils.exec('hyprctl -j')) instead");
+
         const [success, out, err] =
             GLib.spawn_command_line_sync(`hyprctl -j ${cmd}`);
 

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -5,7 +5,14 @@ import { execAsync } from '../utils.js';
 
 const HIS = GLib.getenv('HYPRLAND_INSTANCE_SIGNATURE');
 
-class ActiveClient extends Service {
+class Active extends Service {
+    updateProperty(prop: string, value: unknown): void {
+        super.updateProperty(prop, value);
+        this.emit('changed');
+    }
+}
+
+class ActiveClient extends Active {
     static {
         Service.register(this, {}, {
             'address': ['string'],
@@ -23,7 +30,7 @@ class ActiveClient extends Service {
     get class() { return this._class; }
 }
 
-class ActiveWorkspace extends Service {
+class ActiveWorkspace extends Active {
     static {
         Service.register(this, {}, {
             'id': ['int'],

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -1,6 +1,5 @@
 import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
-import GObject from 'gi://GObject';
 import Service from './service.js';
 import { ensureDirectory, timeout } from '../utils.js';
 import { CACHE_DIR } from '../utils.js';
@@ -27,10 +26,9 @@ type MprisMetadata = {
     [key: string]: unknown
 }
 
-class MprisPlayer extends GObject.Object {
+class MprisPlayer extends Service {
     static {
         Service.register(this, {
-            'changed': [],
             'closed': [],
             'position': ['int'],
         }, {
@@ -197,6 +195,7 @@ class MprisPlayer extends GObject.Object {
             'position',
             'volume',
         ].map(prop => this.notify(prop));
+        this.emit('changed');
     }
 
     private _cacheCoverArt() {
@@ -222,7 +221,7 @@ class MprisPlayer extends GObject.Object {
             null, null, (source, result) => {
                 try {
                     source.copy_finish(result);
-                    this.notify('cover-path');
+                    this.changed('cover-path');
                 }
                 catch (e) {
                     logError(e as Error, `failed to cache ${this._coverPath}`);

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -315,6 +315,10 @@ class MprisService extends Service {
             this.connect(signal, () => this.emit('changed'));
         });
 
+        ['player-closed', 'player-added'].map(signal => {
+            this.connect(signal, () => this.notify('players'));
+        });
+
         this._onProxyReady();
     }
 

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -55,35 +55,41 @@ class MprisPlayer extends GObject.Object {
         });
     }
 
-    busName: string;
-    name: string;
-    entry!: string;
-    identity!: string;
+    get bus_name() { return this._busName; }
+    get name() { return this._name; }
+    get entry() { return this._entry; }
+    get identity() { return this._identity; }
 
-    trackid!: string;
-    trackArtists!: string[];
-    trackTitle!: string;
-    trackCoverUrl!: string;
-    coverPath!: string;
-    playBackStatus!: PlaybackStatus;
-    canGoNext!: boolean;
-    canGoPrev!: boolean;
-    canPlay!: boolean;
-    shuffleStatus!: boolean | null;
-    loopStatus!: LoopStatus | null;
-    length!: number;
+    get trackid() { return this._trackid; }
+    get track_artists() { return this._trackArtists; }
+    get track_title() { return this._trackTitle; }
+    get track_cover_url() { return this._trackCoverUrl; }
+    get cover_path() { return this._coverPath; }
+    get play_back_status() { return this._playBackStatus; }
+    get can_go_next() { return this._canGoNext; }
+    get can_go_prev() { return this._canGoPrev; }
+    get can_play() { return this._canPlay; }
+    get shuffle_status() { return this._shuffleStatus; }
+    get loop_status() { return this._loopStatus; }
+    get length() { return this._length; }
 
-    get bus_name() { return this.busName; }
-    get track_artists() { return this.trackArtists; }
-    get track_title() { return this.trackTitle; }
-    get track_cover_url() { return this.trackCoverUrl; }
-    get cover_path() { return this.coverPath; }
-    get play_back_status() { return this.playBackStatus; }
-    get can_go_next() { return this.canGoNext; }
-    get can_go_prev() { return this.canGoPrev; }
-    get can_play() { return this.canPlay; }
-    get shuffle_status() { return this.shuffleStatus; }
-    get loop_status() { return this.loopStatus; }
+    private _busName: string;
+    private _name: string;
+    private _entry!: string;
+    private _identity!: string;
+
+    private _trackid!: string;
+    private _trackArtists!: string[];
+    private _trackTitle!: string;
+    private _trackCoverUrl!: string;
+    private _coverPath!: string;
+    private _playBackStatus!: PlaybackStatus;
+    private _canGoNext!: boolean;
+    private _canGoPrev!: boolean;
+    private _canPlay!: boolean;
+    private _shuffleStatus!: boolean | null;
+    private _loopStatus!: LoopStatus | null;
+    private _length!: number;
 
     private _binding: { mpris: number, player: number };
     private _mprisProxy: MprisProxy;
@@ -92,8 +98,8 @@ class MprisPlayer extends GObject.Object {
     constructor(busName: string) {
         super();
 
-        this.busName = busName;
-        this.name = busName.substring(23).split('.')[0];
+        this._busName = busName;
+        this._name = busName.substring(23).split('.')[0];
 
         this._binding = { mpris: 0, player: 0 };
         this._mprisProxy = new MprisProxy(
@@ -124,8 +130,8 @@ class MprisPlayer extends GObject.Object {
                     this.close();
             });
 
-        this.identity = this._mprisProxy.Identity;
-        this.entry = this._mprisProxy.DesktopEntry;
+        this._identity = this._mprisProxy.Identity;
+        this._entry = this._mprisProxy.DesktopEntry;
         if (!this._mprisProxy.g_name_owner)
             this.close();
     }
@@ -160,19 +166,19 @@ class MprisPlayer extends GObject.Object {
             ? -1
             : Number.parseInt(`${length}`.substring(0, 3));
 
-        this.shuffleStatus = this._playerProxy.Shuffle;
-        this.loopStatus = this._playerProxy.LoopStatus as LoopStatus;
-        this.canGoNext = this._playerProxy.CanGoNext;
-        this.canGoPrev = this._playerProxy.CanGoPrevious;
-        this.canPlay = this._playerProxy.CanPlay;
-        this.playBackStatus =
+        this._shuffleStatus = this._playerProxy.Shuffle;
+        this._loopStatus = this._playerProxy.LoopStatus as LoopStatus;
+        this._canGoNext = this._playerProxy.CanGoNext;
+        this._canGoPrev = this._playerProxy.CanGoPrevious;
+        this._canPlay = this._playerProxy.CanPlay;
+        this._playBackStatus =
             this._playerProxy.PlaybackStatus as PlaybackStatus;
 
-        this.trackid = metadata['mpris:trackid'];
-        this.trackArtists = trackArtists;
-        this.trackTitle = trackTitle;
-        this.trackCoverUrl = trackCoverUrl;
-        this.length = length;
+        this._trackid = metadata['mpris:trackid'];
+        this._trackArtists = trackArtists;
+        this._trackTitle = trackTitle;
+        this._trackCoverUrl = trackCoverUrl;
+        this._length = length;
         this._cacheCoverArt();
 
         [
@@ -194,23 +200,22 @@ class MprisPlayer extends GObject.Object {
     }
 
     private _cacheCoverArt() {
-        this.coverPath = MEDIA_CACHE_PATH + '/' +
-            `${this.trackArtists.join(', ')}-${this.trackTitle}`
+        this._coverPath = MEDIA_CACHE_PATH + '/' +
+            `${this._trackArtists.join(', ')}-${this._trackTitle}`
                 .replace(/[\,\*\?\"\<\>\|\#\:\?\/\'\(\)]/g, '');
 
-        if (this.coverPath.length > 255)
-            this.coverPath = this.coverPath.substring(0, 255);
+        if (this._coverPath.length > 255)
+            this._coverPath = this._coverPath.substring(0, 255);
 
-        const { trackCoverUrl, coverPath } = this;
-        if (trackCoverUrl === '' || coverPath === '')
+        if (this._trackCoverUrl === '' || this._coverPath === '')
             return;
 
-        if (GLib.file_test(coverPath, GLib.FileTest.EXISTS))
+        if (GLib.file_test(this._coverPath, GLib.FileTest.EXISTS))
             return;
 
         ensureDirectory(MEDIA_CACHE_PATH);
-        Gio.File.new_for_uri(trackCoverUrl).copy_async(
-            Gio.File.new_for_path(coverPath),
+        Gio.File.new_for_uri(this._trackCoverUrl).copy_async(
+            Gio.File.new_for_path(this._coverPath),
             Gio.FileCopyFlags.OVERWRITE,
             GLib.PRIORITY_DEFAULT,
             // @ts-expect-error
@@ -220,7 +225,7 @@ class MprisPlayer extends GObject.Object {
                     this.notify('cover-path');
                 }
                 catch (e) {
-                    logError(e as Error, `failed to cache ${coverPath}`);
+                    logError(e as Error, `failed to cache ${this._coverPath}`);
                 }
             },
         );
@@ -243,7 +248,7 @@ class MprisPlayer extends GObject.Object {
             Gio.BusType.SESSION,
             Gio.DBusProxyFlags.NONE,
             null,
-            this.busName,
+            this._busName,
             '/org/mpris/MediaPlayer2',
             'org.mpris.MediaPlayer2.Player',
             null,

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -164,37 +164,18 @@ class MprisPlayer extends Service {
             ? -1
             : Number.parseInt(`${length}`.substring(0, 3));
 
-        this._shuffleStatus = this._playerProxy.Shuffle;
-        this._loopStatus = this._playerProxy.LoopStatus as LoopStatus;
-        this._canGoNext = this._playerProxy.CanGoNext;
-        this._canGoPrev = this._playerProxy.CanGoPrevious;
-        this._canPlay = this._playerProxy.CanPlay;
-        this._playBackStatus =
-            this._playerProxy.PlaybackStatus as PlaybackStatus;
-
-        this._trackid = metadata['mpris:trackid'];
-        this._trackArtists = trackArtists;
-        this._trackTitle = trackTitle;
-        this._trackCoverUrl = trackCoverUrl;
-        this._length = length;
+        this.updateProperty('shuffle-status', this._playerProxy.Shuffle);
+        this.updateProperty('loop-status', this._playerProxy.LoopStatus);
+        this.updateProperty('can-go-next', this._playerProxy.CanGoNext);
+        this.updateProperty('can-go-prev', this._playerProxy.CanGoPrevious);
+        this.updateProperty('can-play', this._playerProxy.CanPlay);
+        this.updateProperty('play-back-status', this._playerProxy.PlaybackStatus);
+        this.updateProperty('trackid', metadata['mpris:trackid']);
+        this.updateProperty('track-artists', trackArtists);
+        this.updateProperty('track-title', trackTitle);
+        this.updateProperty('track-cover-url', trackCoverUrl);
+        this.updateProperty('length', length);
         this._cacheCoverArt();
-
-        [
-            'trackid',
-            'track-artists',
-            'track-title',
-            'track-cover-url',
-            'cover-path',
-            'play-back-status',
-            'can-go-next',
-            'can-go-prev',
-            'can-play',
-            'shuffle-status',
-            'loop-status',
-            'length',
-            'position',
-            'volume',
-        ].map(prop => this.notify(prop));
         this.emit('changed');
     }
 
@@ -260,6 +241,7 @@ class MprisPlayer extends Service {
     set position(time: number) {
         const micro = Math.floor(time * 1_000_000);
         this._playerProxy.SetPositionAsync(this.trackid, micro);
+        this.notify('position');
         this.emit('position', time);
     }
 

--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -114,8 +114,7 @@ class Wifi extends Service {
         });
     }
 
-    get access_points() { return this.accessPoints; }
-    get accessPoints() {
+    get access_points() {
         return this._device.get_access_points().map(ap => ({
             bssid: ap.bssid,
             address: ap.hw_address,
@@ -147,8 +146,7 @@ class Wifi extends Service {
 
     get state() { return _DEVICE_STATE(this._device); }
 
-    get icon_name() { return this.iconName; }
-    get iconName() {
+    get icon_name() {
         const iconNames: [number, string][] = [
             [80, 'excellent'],
             [60, 'good'],
@@ -201,8 +199,7 @@ class Wired extends Service {
     get speed() { return this._device.get_speed(); }
     get internet() { return _INTERNET(this._device); }
     get state() { return _DEVICE_STATE(this._device); }
-    get icon_name() { return this.iconName; }
-    get iconName() {
+    get icon_name() {
         if (this.internet === 'connecting')
             return 'network-wired-acquiring-symbolic';
 

--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -106,7 +106,7 @@ class Wifi extends Service {
             return;
 
 
-        // TODO make signals acutally signal when they should
+        // TODO make signals actually signal when they should
         this._apBind = this._ap.connect('notify::strength', () => {
             this.emit('changed');
             ['enabled', 'internet', 'strength', 'access-points', 'ssid', 'state', 'icon-name']
@@ -188,7 +188,7 @@ class Wired extends Service {
         super();
         this._device = device;
 
-        // TODO make signals acutally signal when they should
+        // TODO make signals actually signal when they should
         this._device.connect('notify::speed', () => {
             this.emit('changed');
             ['speed', 'internet', 'state', 'icon-name']

--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -88,12 +88,6 @@ class Wifi extends Service {
             ]);
             this._activeAp();
         }
-
-        // TODO optimize notify signals
-        this.connect('changed', () => {
-            ['enabled', 'internet', 'strength', 'access-points', 'ssid', 'state', 'icon-name']
-                .map(prop => this.notify(prop));
-        });
     }
 
     scan() {
@@ -111,8 +105,13 @@ class Wifi extends Service {
         if (!this._ap)
             return;
 
-        this._apBind = this._ap.connect(
-            'notify::strength', () => this.emit('changed'));
+
+        // TODO make signals acutally signal when they should
+        this._apBind = this._ap.connect('notify::strength', () => {
+            this.emit('changed');
+            ['enabled', 'internet', 'strength', 'access-points', 'ssid', 'state', 'icon-name']
+                .map(prop => this.notify(prop));
+        });
     }
 
     get access_points() { return this.accessPoints; }
@@ -191,7 +190,7 @@ class Wired extends Service {
         super();
         this._device = device;
 
-        // TODO optimize notify signals
+        // TODO make signals acutally signal when they should
         this._device.connect('notify::speed', () => {
             this.emit('changed');
             ['speed', 'internet', 'state', 'icon-name']

--- a/src/service/notifications.ts
+++ b/src/service/notifications.ts
@@ -147,7 +147,9 @@ class Notification extends Service {
     }
 
     static fromJson(json: NotifcationJson) {
-        const { id, appName, appEntry, appIcon, summary, body, actions, urgency, time, image } = json;
+        const { id, appName, appEntry, appIcon, summary,
+            body, actions, urgency, time, image } = json;
+
         const n = new Notification(appName, id, appIcon, summary, body, [], {}, false);
         n._actions = actions;
         n._appEntry = appEntry;
@@ -337,7 +339,7 @@ class NotificationsService extends Service {
                 .map((n: NotifcationJson) => Notification.fromJson(n));
 
             for (const n of notifications) {
-                this._addNotification(n)
+                this._addNotification(n);
                 if (n.id > this._idCount)
                     this._idCount = n.id + 1;
             }

--- a/src/service/notifications.ts
+++ b/src/service/notifications.ts
@@ -56,7 +56,6 @@ class Notification extends Service {
             'urgency': ['string'],
             'time': ['int'],
             'image': ['string'],
-            'hints': ['jsobject'],
             'popup': ['boolean'],
         });
     }
@@ -237,11 +236,6 @@ class NotificationsService extends Service {
         return this._notifications.get(id);
     }
 
-    Clear() {
-        for (const [id] of this._notifications)
-            this.CloseNotification(id);
-    }
-
     Notify(
         appName: string,
         replacesId: number,
@@ -252,7 +246,7 @@ class NotificationsService extends Service {
         hints: Hints,
     ) {
         const id = replacesId || this._idCount++;
-        const n = new Notification(appName, id, appIcon, summary, body, acts, hints, this.dnd);
+        const n = new Notification(appName, id, appIcon, summary, body, acts, hints, !this.dnd);
         timeout(App.config.notificationPopupTimeout, () => this.DismissNotification(id));
         this._addNotification(n);
         !this._dnd && this.notify('popups');
@@ -262,6 +256,8 @@ class NotificationsService extends Service {
         this._cache();
         return id;
     }
+
+    Clear() { this.clear(); }
 
     DismissNotification(id: number) {
         this._notifications.get(id)?.dismiss();
@@ -281,6 +277,11 @@ class NotificationsService extends Service {
 
     GetServerInformation() {
         return new GLib.Variant('(ssss)', [pkg.name, 'Aylur', pkg.version, '1.2']);
+    }
+
+    clear() {
+        for (const [id] of this._notifications)
+            this.CloseNotification(id);
     }
 
     private _addNotification(n: Notification) {
@@ -385,7 +386,7 @@ export default class Notifications {
         Notifications.instance.CloseNotification(id);
     }
 
-    static clear() { Notifications.instance.Clear(); }
+    static clear() { Notifications.instance.clear(); }
 
     static getPopup(id: number) { return Notifications.instance.getPopup(id); }
     static getNotification(id: number) { return Notifications.instance.getNotification(id); }

--- a/src/service/notifications.ts
+++ b/src/service/notifications.ts
@@ -71,8 +71,7 @@ class NotificationsService extends Service {
     get dnd() { return this._dnd; }
     set dnd(value: boolean) {
         this._dnd = value;
-        this.notify('dnd');
-        this.emit('changed');
+        this.changed('dnd');
     }
 
     get notifications() { return Array.from(this._notifications.values()); }
@@ -141,7 +140,6 @@ class NotificationsService extends Service {
         this._cache();
         this.notify('notifications');
         !this._dnd && this.notify('popups');
-
         this.emit('notified', id);
         this.emit('changed');
         return id;
@@ -153,9 +151,8 @@ class NotificationsService extends Service {
             return;
 
         n.popup = false;
-        this.notify('popups');
         this.emit('dismissed', id);
-        this.emit('changed');
+        this.changed('popups');
     }
 
     CloseNotification(id: number) {
@@ -228,7 +225,7 @@ class NotificationsService extends Service {
                 this._notifications.set(n.id, n);
             }
 
-            this.emit('changed');
+            this.changed('notifications');
         } catch (_) {
             // most likely there is no cache yet
         }

--- a/src/service/notifications.ts
+++ b/src/service/notifications.ts
@@ -3,7 +3,6 @@ import GdkPixbuf from 'gi://GdkPixbuf';
 import GLib from 'gi://GLib';
 import Service from './service.js';
 import App from '../app.js';
-
 import {
     CACHE_DIR, ensureDirectory,
     loadInterfaceXML, readFileAsync,
@@ -14,7 +13,7 @@ const NOTIFICATIONS_CACHE_PATH = `${CACHE_DIR}/notifications`;
 const CACHE_FILE = NOTIFICATIONS_CACHE_PATH + '/notifications.json';
 const NotificationIFace = loadInterfaceXML('org.freedesktop.Notifications');
 
-interface action {
+interface Action {
     id: string
     label: string
 }
@@ -25,23 +24,161 @@ interface Hints {
     'urgency'?: GLib.Variant<'y'>
 }
 
-const _URGENCY = ['low', 'normal', 'critical'];
-
-interface Notification {
+interface NotifcationJson {
     id: number
     appName: string
-    appEntry?: string
+    appEntry: string | null
     appIcon: string
     summary: string
     body: string
-    actions: action[]
+    actions: Action[]
     urgency: string
     time: number
     image: string | null
-    popup: boolean
-    dismiss: () => void
-    close: () => void
-    invoke: (id: string) => void
+}
+
+const _URGENCY = ['low', 'normal', 'critical'];
+
+class Notification extends Service {
+    static {
+        Service.register(this, {
+            'dismissed': [],
+            'closed': [],
+            'invoked': ['string'],
+        }, {
+            'id': ['int'],
+            'app-name': ['string'],
+            'app-entry': ['string'],
+            'app-icon': ['string'],
+            'summary': ['string'],
+            'body': ['string'],
+            'actions': ['jsobject'],
+            'urgency': ['string'],
+            'time': ['int'],
+            'image': ['string'],
+            'hints': ['jsobject'],
+            'popup': ['boolean'],
+        });
+    }
+
+    _id: number;
+    _appName: string;
+    _appEntry: string | null;
+    _appIcon: string;
+    _summary: string;
+    _body: string;
+    _actions: Action[] = [];
+    _urgency: string;
+    _time: number;
+    _image: string | null;
+    _popup: boolean;
+
+    get id() { return this._id; }
+    get app_name() { return this._appName; }
+    get app_entry() { return this._appEntry; }
+    get app_icon() { return this._appIcon; }
+    get summary() { return this._summary; }
+    get body() { return this._body; }
+    get actions() { return this._actions; }
+    get urgency() { return this._urgency; }
+    get time() { return this._time; }
+    get image() { return this._image; }
+    get popup() { return this._popup; }
+
+    constructor(
+        appName: string,
+        id: number,
+        appIcon: string,
+        summary: string,
+        body: string,
+        acts: string[],
+        hints: Hints,
+        popup: boolean,
+    ) {
+        super();
+
+        for (let i = 0; i < acts.length; i += 2) {
+            acts[i + 1] !== '' && this._actions.push({
+                label: acts[i + 1],
+                id: acts[i],
+            });
+        }
+
+        this._urgency = _URGENCY[hints['urgency']?.unpack() || 1];
+        this._id = id;
+        this._appName = appName;
+        this._appEntry = hints['desktop-entry']?.unpack() || null;
+        this._appIcon = appIcon;
+        this._summary = summary;
+        this._body = body;
+        this._time = GLib.DateTime.new_now_local().to_unix();
+        this._image = this._parseImageData(hints['image-data']) || this._appIconIsFile();
+        this._popup = popup;
+    }
+
+    dismiss() {
+        this._popup = false;
+        this.changed('popup');
+        this.emit('dismissed');
+    }
+
+    close() {
+        this.emit('closed');
+    }
+
+    invoke(id: string) {
+        this.emit('invoked', id);
+        this.close();
+    }
+
+    toJson(cacheActions = App.config.cacheNotificationActions) {
+        return {
+            id: this._id,
+            appName: this._appName,
+            appEntry: this._appEntry,
+            appIcon: this._appIcon,
+            summary: this._summary,
+            body: this._body,
+            actions: cacheActions ? this._actions : [],
+            urgency: this._urgency,
+            time: this._time,
+            image: this._image,
+        };
+    }
+
+    static fromJson(json: NotifcationJson) {
+        const { id, appName, appEntry, appIcon, summary, body, actions, urgency, time, image } = json;
+        const n = new Notification(appName, id, appIcon, summary, body, [], {}, false);
+        n._actions = actions;
+        n._appEntry = appEntry;
+        n._urgency = urgency;
+        n._time = time;
+        n._image = image;
+        return n;
+    }
+
+    private _appIconIsFile() {
+        return GLib.file_test(this._appIcon, GLib.FileTest.EXISTS) ? this._appIcon : null;
+    }
+
+    private _parseImageData(imageData?: GLib.Variant<'(iiibiiay)'>) {
+        if (!imageData)
+            return null;
+
+        ensureDirectory(NOTIFICATIONS_CACHE_PATH);
+        const fileName = NOTIFICATIONS_CACHE_PATH + `/${this._id}`;
+        const [w, h, rs, alpha, bps, _, data] = imageData.recursiveUnpack();
+        const pixbuf = GdkPixbuf.Pixbuf.new_from_bytes(
+            data, GdkPixbuf.Colorspace.RGB, alpha, bps, w, h, rs);
+
+        const outputStream = Gio.File.new_for_path(fileName)
+            .replace(null, false, Gio.FileCreateFlags.NONE, null);
+
+        pixbuf.save_to_streamv(outputStream, 'png', null, null, null);
+        outputStream.close(null);
+
+        return fileName;
+    }
 }
 
 class NotificationsService extends Service {
@@ -70,14 +207,16 @@ class NotificationsService extends Service {
         this._register();
     }
 
-
     get dnd() { return this._dnd; }
     set dnd(value: boolean) {
         this._dnd = value;
         this.changed('dnd');
     }
 
-    get notifications() { return Array.from(this._notifications.values()); }
+    get notifications() {
+        return Array.from(this._notifications.values());
+    }
+
     get popups() {
         const list = [];
         for (const [, notification] of this._notifications) {
@@ -110,83 +249,28 @@ class NotificationsService extends Service {
         acts: string[],
         hints: Hints,
     ) {
-        const actions: action[] = [];
-        for (let i = 0; i < acts.length; i += 2) {
-            if (acts[i + 1] !== '') {
-                actions.push({
-                    label: acts[i + 1],
-                    id: acts[i],
-                });
-            }
-        }
-
         const id = replacesId || this._idCount++;
-        const urgency = _URGENCY[hints['urgency']?.unpack() || 1];
-        const notification = {
-            id,
-            appName,
-            appEntry: hints['desktop-entry']?.unpack(),
-            appIcon,
-            summary,
-            body,
-            actions,
-            urgency,
-            time: GLib.DateTime.new_now_local().to_unix(),
-            popup: !this._dnd,
-            image: this._parseImage(
-                id, hints['image-data']) ||
-                this._isFile(appIcon),
-
-            dismiss: () => this.DismissNotification(id),
-            close: () => this.CloseNotification(id),
-            invoke: (actionId: string) => this.InvokeAction(id, actionId),
-        };
-        this._notifications.set(id, notification);
-
+        const n = new Notification(appName, id, appIcon, summary, body, acts, hints, this.dnd);
         timeout(App.config.notificationPopupTimeout, () => this.DismissNotification(id));
-
-        this._cache();
-        this.notify('notifications');
+        this._addNotification(n);
         !this._dnd && this.notify('popups');
+        this.notify('notifications');
         this.emit('notified', id);
         this.emit('changed');
+        this._cache();
         return id;
     }
 
     DismissNotification(id: number) {
-        const n = this._notifications.get(id);
-        if (!n)
-            return;
-
-        n.popup = false;
-        this.emit('dismissed', id);
-        this.changed('popups');
+        this._notifications.get(id)?.dismiss();
     }
 
     CloseNotification(id: number) {
-        if (!this._notifications.has(id))
-            return;
-
-        this._dbus.emit_signal('NotificationClosed',
-            GLib.Variant.new('(uu)', [id, 3]));
-
-        this._notifications.delete(id);
-        this.notify('notifications');
-        this.notify('popups');
-        this.emit('closed', id);
-        this.emit('changed');
-        this._cache();
+        this._notifications.get(id)?.close();
     }
 
     InvokeAction(id: number, actionId: string) {
-        if (!this._notifications.has(id))
-            return;
-
-        this._dbus.emit_signal('ActionInvoked',
-            GLib.Variant.new('(us)', [id, actionId]));
-
-        this.CloseNotification(id);
-        this._cache();
+        this._notifications.get(id)?.invoke(actionId);
     }
 
     GetCapabilities() {
@@ -194,12 +278,36 @@ class NotificationsService extends Service {
     }
 
     GetServerInformation() {
-        return new GLib.Variant('(ssss)', [
-            pkg.name,
-            'Aylur',
-            pkg.version,
-            '1.2',
-        ]);
+        return new GLib.Variant('(ssss)', [pkg.name, 'Aylur', pkg.version, '1.2']);
+    }
+
+    private _addNotification(n: Notification) {
+        n.connect('dismissed', this._onDismissed.bind(this));
+        n.connect('closed', this._onClosed.bind(this));
+        n.connect('invoked', this._onInvoked.bind(this));
+        this._notifications.set(n.id, n);
+    }
+
+    private _onDismissed(n: Notification) {
+        this.emit('dismissed', n.id);
+        this.changed('popups');
+    }
+
+    private _onClosed(n: Notification) {
+        this._dbus.emit_signal('NotificationClosed',
+            GLib.Variant.new('(uu)', [n.id, 3]));
+
+        this._notifications.delete(n.id);
+        this.notify('notifications');
+        this.notify('popups');
+        this.emit('closed', n.id);
+        this.emit('changed');
+        this._cache();
+    }
+
+    private _onInvoked(n: Notification, id: string) {
+        this._dbus.emit_signal('ActionInvoked',
+            GLib.Variant.new('(us)', [n.id, id]));
     }
 
     private _register() {
@@ -225,16 +333,13 @@ class NotificationsService extends Service {
     private async _readFromFile() {
         try {
             const file = await readFileAsync(CACHE_FILE);
-            const notifications = JSON.parse(file as string) as Notification[];
+            const notifications = JSON.parse(file)
+                .map((n: NotifcationJson) => Notification.fromJson(n));
+
             for (const n of notifications) {
+                this._addNotification(n)
                 if (n.id > this._idCount)
                     this._idCount = n.id + 1;
-
-                n.dismiss = () => this.DismissNotification(n.id);
-                n.close = () => this.CloseNotification(n.id);
-                n.invoke = (actionId: string) => this.InvokeAction(n.id, actionId);
-
-                this._notifications.set(n.id, n);
             }
 
             this.changed('notifications');
@@ -243,45 +348,10 @@ class NotificationsService extends Service {
         }
     }
 
-    private _isFile(path: string) {
-        return GLib.file_test(path, GLib.FileTest.EXISTS) ? path : null;
-    }
-
-    private _parseImage(id: number, image_data?: GLib.Variant<'(iiibiiay)'>) {
-        if (!image_data)
-            return null;
-
-        ensureDirectory(NOTIFICATIONS_CACHE_PATH);
-        const fileName = NOTIFICATIONS_CACHE_PATH + `/${id}`;
-        const image = image_data.recursiveUnpack();
-        const pixbuf = GdkPixbuf.Pixbuf.new_from_bytes(
-            image[6],
-            GdkPixbuf.Colorspace.RGB,
-            image[3],
-            image[4],
-            image[0],
-            image[1],
-            image[2],
-        );
-
-        const output_stream =
-            Gio.File.new_for_path(fileName)
-                .replace(null, false, Gio.FileCreateFlags.NONE, null);
-
-        pixbuf.save_to_streamv(output_stream, 'png', null, null, null);
-        output_stream.close(null);
-
-        return fileName;
-    }
-
     private _cache() {
-        const arr = Array.from(this._notifications.values());
-        const notifications = App.config.cacheNotificationActions
-            ? arr : arr.map(n => ({ ...n, actions: [], popup: false }));
-
         ensureDirectory(NOTIFICATIONS_CACHE_PATH);
-        const json = JSON.stringify(notifications, null, 2);
-        writeFile(json, CACHE_FILE).catch(logError);
+        const arr = Array.from(this._notifications.values()).map(n => n.toJson());
+        writeFile(JSON.stringify(arr, null, 2), CACHE_FILE).catch(logError);
     }
 }
 

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -88,6 +88,21 @@ export default class Service extends GObject.Object {
         connect(this, widget, callback, event);
     }
 
+    updateProperty(prop: string, value: unknown) {
+        // @ts-expect-error
+        if (this[`_${prop}`] === value)
+            return;
+
+        const privateProp = prop
+            .split('-')
+            .map((w, i) => i > 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w)
+            .join('');
+
+        // @ts-expect-error
+        this[`_${privateProp}`] = value;
+        this.notify(prop);
+    }
+
     changed(property: string) {
         this.notify(property);
         this.emit('changed');

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -80,14 +80,6 @@ export default class Service extends GObject.Object {
         GObject.registerClass({ Signals, Properties }, service);
     }
 
-    static export(api: { instance: object }, name: string) {
-        // @ts-expect-error
-        Service[name] = api;
-        console.error('Service.register is DEPRECATED.\n' +
-            "Simply do Service['YourService'] = YourService\n" +
-            'or just export and import your YourService');
-    }
-
     connectWidget(
         widget: Gtk.Widget,
         callback: (widget: Gtk.Widget, ...args: unknown[]) => void,

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -3,6 +3,9 @@ import Gtk from 'gi://Gtk?version=3.0';
 import { connect } from '../utils.js';
 import { type Ctor } from 'gi-types/gobject2.js';
 
+type PspecType = 'jsobject' | 'string' | 'int' | 'float' | 'boolean';
+type PspecFlag = 'rw' | 'r' | 'w';
+
 export default class Service extends GObject.Object {
     static {
         GObject.registerClass({
@@ -16,22 +19,65 @@ export default class Service extends GObject.Object {
             api._instance = new service();
     }
 
-    static register(service: Ctor, signals?: { [signal: string]: string[] }) {
+    static pspec(name: string, type: PspecType = 'jsobject', handle: PspecFlag = 'r') {
+        const flags = (() => {
+            switch (handle) {
+                case 'w': return GObject.ParamFlags.WRITABLE;
+                case 'r': return GObject.ParamFlags.READABLE;
+                case 'rw':
+                default: return GObject.ParamFlags.READWRITE;
+            }
+        })();
+
+        switch (type) {
+            case 'string': return GObject.ParamSpec.string(
+                name, name, name, flags, '');
+
+            case 'int': return GObject.ParamSpec.int64(
+                name, name, name, flags,
+                Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER, 0);
+
+            case 'float': return GObject.ParamSpec.float(
+                name, name, name, flags,
+                -1, 1, 0);
+
+            case 'boolean': return GObject.ParamSpec.boolean(
+                name, name, name, flags, false);
+
+            // @ts-expect-error
+            default: return GObject.ParamSpec.jsobject(
+                name, name, name, flags, null);
+        }
+    }
+
+    static register(
+        service: Ctor,
+        signals?: { [signal: string]: string[] },
+        properties?: { [prop: string]: [type?: PspecType, handle?: PspecFlag] },
+    ) {
         const Signals: {
             [signal: string]: { param_types: GObject.GType<unknown>[] }
         } = {};
 
+        const Properties: {
+            [prop: string]: GObject.ParamSpec,
+        } = {};
+
         if (signals) {
-            Object.keys(signals).forEach(signal =>
-                Signals[signal] = {
-                    param_types: signals[signal].map(t =>
-                        // @ts-expect-error
-                        GObject[`TYPE_${t.toUpperCase()}`]),
-                },
+            Object.keys(signals).forEach(signal => Signals[signal] = {
+                param_types: signals[signal].map(t =>
+                    // @ts-expect-error
+                    GObject[`TYPE_${t.toUpperCase()}`]),
+            });
+        }
+
+        if (properties) {
+            Object.keys(properties).forEach(prop =>
+                Properties[prop] = Service.pspec(prop, ...properties[prop]),
             );
         }
 
-        GObject.registerClass({ Signals }, service);
+        GObject.registerClass({ Signals, Properties }, service);
     }
 
     static export(api: { instance: object }, name: string) {

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -95,5 +95,10 @@ export default class Service extends GObject.Object {
     ) {
         connect(this, widget, callback, event);
     }
+
+    changed(property: string) {
+        this.notify(property);
+        this.emit('changed');
+    }
 }
 

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -19,6 +19,16 @@ export class TrayItem extends Service {
         Service.register(this, {
             'removed': ['string'],
             'ready': [],
+        }, {
+            'menu': ['jsobject'],
+            'category': ['string'],
+            'id': ['string'],
+            'title': ['string'],
+            'status': ['string'],
+            'window-id': ['int'],
+            'is-menu': ['boolean'],
+            'tooltip-markup': ['string'],
+            'icon': ['jsobject'],
         });
     }
 
@@ -65,6 +75,10 @@ export class TrayItem extends Service {
             ? (this.menu as unknown as Gtk.Menu).popup_at_pointer(event)
             : this._proxy.ContextMenuAsync(event.get_root_coords()[1], event.get_root_coords()[2]);
     }
+
+    get window_id() { return this.windowId; }
+    get is_menu() { return this.isMenu; }
+    get tooltip_markup() { return this.tooltipMarkup; }
 
     get category() { return this._proxy.Category; }
     get id() { return this._proxy.Id; }

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -139,19 +139,24 @@ export class TrayItem extends Service {
                 if (!proxy.g_name_owner)
                     this.emit('removed', this._busName);
             }],
-            ['g-signal', () => {
-                this._refreshAllProperties();
-                this.emit('changed');
-            }],
+            ['g-signal', this._refreshAllProperties.bind(this)],
             ['g-properties-changed', () => this.emit('changed')],
         ]);
 
         ['Title', 'Icon', 'AttentionIcon', 'OverlayIcon', 'ToolTip', 'Status']
             .forEach(prop => proxy.connectSignal(`New${prop}`, () => {
-                this.emit('changed');
+                this._notify();
             }));
 
         this.emit('ready');
+    }
+
+    _notify() {
+        [
+            'menu', 'category', 'id', 'title', 'status',
+            'window-id', 'is-menu', 'tooltip-markup', 'icon',
+        ].forEach(prop => this.notify(prop));
+        this.emit('changed');
     }
 
     private _refreshAllProperties() {
@@ -170,6 +175,8 @@ export class TrayItem extends Service {
         Object.entries(properties).map(([propertyName, value]) => {
             this._proxy.set_cached_property(propertyName, value);
         });
+
+        this._notify();
     }
 
     private _getPixbuf(pixMapArray: [number, number, Uint8Array][]) {

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -205,6 +205,8 @@ class SystemTrayService extends Service {
         Service.register(this, {
             'added': ['string'],
             'removed': ['string'],
+        }, {
+            'items': ['jsobject'],
         });
     }
 
@@ -214,7 +216,9 @@ class SystemTrayService extends Service {
     get IsStatusNotifierHostRegistered() { return true; }
     get ProtocolVersion() { return 0; }
     get RegisteredStatusNotifierItems() { return Array.from(this._items.keys()); }
-    get items() { return this._items; }
+
+    get items() { return Array.from(this._items.values()); }
+    getItem(name: string) { return this._items.get(name); }
 
     constructor() {
         super();
@@ -273,10 +277,6 @@ class SystemTrayService extends Service {
             );
         });
     }
-
-    getItem(name: string) {
-        return this._items.get(name);
-    }
 }
 
 
@@ -288,7 +288,7 @@ export default class SystemTray {
         return SystemTray._instance;
     }
 
-    static get items() { return Array.from(SystemTray.instance.items.values()); }
-    static getItem(name: string) { return SystemTray._instance.getItem(name); }
+    static get items() { return SystemTray.instance.items; }
+    static getItem(name: string) { return SystemTray.instance.getItem(name); }
 }
 

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -267,6 +267,7 @@ class SystemTrayService extends Service {
         item.connect('ready', () => {
             this._items.set(busName, item);
             this.emit('added', busName);
+            this.notify('items');
             this.emit('changed');
             this._dbus.emit_signal(
                 'StatusNotifierItemRegistered',
@@ -276,6 +277,7 @@ class SystemTrayService extends Service {
         item.connect('removed', () => {
             this._items.delete(busName);
             this.emit('removed', busName);
+            this.notify('items');
             this.emit('changed');
             this._dbus.emit_signal(
                 'StatusNotifierItemUnregistered',

--- a/src/service/systemtray.ts
+++ b/src/service/systemtray.ts
@@ -76,18 +76,14 @@ export class TrayItem extends Service {
             : this._proxy.ContextMenuAsync(event.get_root_coords()[1], event.get_root_coords()[2]);
     }
 
-    get window_id() { return this.windowId; }
-    get is_menu() { return this.isMenu; }
-    get tooltip_markup() { return this.tooltipMarkup; }
-
     get category() { return this._proxy.Category; }
     get id() { return this._proxy.Id; }
     get title() { return this._proxy.Title; }
     get status() { return this._proxy.Status; }
-    get windowId() { return this._proxy.WindowId; }
-    get isMenu() { return this._proxy.ItemIsMenu; }
+    get window_id() { return this._proxy.WindowId; }
+    get is_menu() { return this._proxy.ItemIsMenu; }
 
-    get tooltipMarkup() {
+    get tooltip_markup() {
         if (!this._proxy.ToolTip)
             return '';
 

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -4,12 +4,12 @@ import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import { execAsync, interval, subprocess } from './utils.js';
 
-type poll = [number, string[] | string | (() => unknown), (out: string) => string];
-type listen = [string[] | string, (out: string) => string] | string[] | string;
+type Poll = [number, string[] | string | (() => unknown), (out: string) => string];
+type Listen = [string[] | string, (out: string) => string] | string[] | string;
 
 interface Options {
-    poll?: poll
-    listen?: listen
+    poll?: Poll
+    listen?: Listen
 }
 
 class AgsVariable extends GObject.Object {
@@ -17,12 +17,19 @@ class AgsVariable extends GObject.Object {
         GObject.registerClass({
             GTypeName: 'AgsVariable',
             Signals: { 'changed': {} },
+            Properties: {
+                // @ts-expect-error
+                'value': GObject.ParamSpec.jsobject(
+                    'value', 'value', 'value',
+                    GObject.ParamFlags.READWRITE, null,
+                ),
+            },
         }, this);
     }
 
     private _value: any;
-    private _poll?: poll;
-    private _listen?: listen;
+    private _poll?: Poll;
+    private _listen?: Listen;
     private _interval?: number;
     private _subprocess?: Gio.Subprocess | null;
 
@@ -122,6 +129,7 @@ class AgsVariable extends GObject.Object {
     getValue() { return this._value; }
     setValue(value: any) {
         this._value = value;
+        this.notify('value');
         this.emit('changed');
     }
 


### PR DESCRIPTION
This PR adds gobject property definitions for the services, which allows for using the `notify::prop-name` signals.
This means, that its obsolete to pass signals to binds because the prop-name is already given, instead this PR introduces a transform method on it

here is an examples usage
```js
const batteryPercent = Label({
    binds: [
        ['label', Battery, 'percent', percent => `${percent}%`],
        ['visible', Battery, 'available'],
    ],

    // this is what it translates to
    connections: [
        [Battery, self => self.label = `${Battery.percent}%`, 'notify::percent'],
        [Battery, self => self.visible = Battery.available, 'notify::visible'],
    ],
});

const variable = ags.Variable('some-string');
const variableBounded = Label({
    binds: [
        ['label', variable],

        // using transform method
        ['someProp', variable, 'value', value => `stringifed ${value}`],
    ],


    // this is what it translates to
    connections: [
        [variable, self => self.label = variable.value, 'notify::value'],
        [variable, self => self.label = `stringifed ${variable.value}`, 'notify::value'],
    ],
});
```

as for custom services, you can define gobject properties with `Service.register` or `GObject.registerClass`
```js
class Brightness extends Service {
    static {
        // second argument is an object describings the properties
        Service.register(this, {
            // signals
        }, {
            // screen-value is a float that is readable and writable
            // has to be kebab-cased
            'screen-value': ['float', 'rw'],
        });
    }

    _screen = 0;

    // the getter has to be in snake_case
    get screen_value() { return this._screen; }

    // the setter has to be in snake_case too
    set screen_value(percent) {
        if (percent < 0)
            percent = 0;

        if (percent > 1)
            percent = 1;

        execAsync(`brightnessctl s ${percent * 100}% -q`)
            .then(() => {
                this._screen = percent;

                this.emit('changed'); // emits "changed"
                this.notify('screen'); // emits "notify::screen"

                // or use Service.changed(propName: string) which does the above two
                // this.changed('screen');
            })
            .catch(print);
    }

    constructor() {
        super();
        this._screen = Number(exec('brightnessctl g'))
            / Number(exec('brightnessctl m'));
    }
}

export default new BrightnessService();
```

then use like this
```js
import Brightness from './brightness.js';

const label = Label({
    binds: [
        ['label', Brightness, 'screen-value', v => `${v}`],
    ],

    connections: [
        [Brightness, label => {
            // all three are valid
            label.label = `${Brightness.screenValue}`;
            label.label = `${Brightness.screen_value}`;
            label.label = `${Brightness['screen-value']}`;
        }, 'notify::screen-value'],
    ]
});
```