### PR TITLE
fix buffer too small error

### DIFF
--- a/src/widgets/label.ts
+++ b/src/widgets/label.ts
@@ -47,7 +47,7 @@ export default class AgsLabel extends Gtk.Label {
                 Pango.parse_markup(label, label.length, '0');
             } catch (e) {
                 if (e instanceof GLib.MarkupError)
-                    label = GLib.markup_escape_text(label, label.length);
+                    label = GLib.markup_escape_text(label, -1);
                 else
                     logError(e as Error);
             }


### PR DESCRIPTION
When the label contains invalid markup, the `GLib.markup_escape_text` function is called. This resulted in a buffer too small error, when the string included emojis. I don't know why this resulted in this error because  `.length` property does take this into account. (`'😅'.length` does return 2).
Fixed this by setting the label length to -1 and letting GLib figure out the length itself.