### PR TITLE
Added more props to battery service

### DIFF
--- a/src/dbus/org.freedesktop.UPower.Device.xml
+++ b/src/dbus/org.freedesktop.UPower.Device.xml
@@ -3,5 +3,10 @@
         <property name="State" type="u" access="read"/>
         <property name="Percentage" type="d" access="read"/>
         <property name="IsPresent" type="b" access="read"/>
+        <property name="TimeToEmpty" type="x" access="read"/>
+        <property name="TimeToFull" type="x" access="read"/>
+        <property name="Energy" type="d" access="read"/>
+        <property name="EnergyFull" type="d" access="read"/>
+        <property name="EnergyRate" type="d" access="read"/>
     </interface>
 </node>

--- a/src/dbus/types.ts
+++ b/src/dbus/types.ts
@@ -43,6 +43,11 @@ export interface BatteryProxy extends Gio.DBusProxy {
     State: number
     Percentage: number
     IsPresent: boolean
+    TimeToEmpty: number
+    TimeToFull: number
+    Energy: number
+    EnergyFull: number
+    EnergyRate: number
 }
 
 export interface StatusNotifierItemProxy extends Gio.DBusProxy {

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -83,7 +83,7 @@ class BatteryService extends Service {
             ? 'battery-level-100-charged-symbolic'
             : `battery-level-${level}${state}-symbolic`;
 
-        const timeRemaining = charged ? this._proxy.TimeToFull : this._proxy.TimeToEmpty;
+        const timeRemaining = charging ? this._proxy.TimeToFull : this._proxy.TimeToEmpty;
 
         const energy = this._proxy.Energy;
 

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -122,15 +122,15 @@ export default class Battery {
     static get icon_name() { return Battery.instance.icon_name; }
     static get ['icon-name']() { return Battery.instance.icon_name; }
 
-    static get time_remaining() { return Battery.instance.time_remaining; }
     static get timeRemaining() { return Battery.instance.time_remaining; }
+    static get time_remaining() { return Battery.instance.time_remaining; }
     static get ['time-remaining']() { return Battery.instance.time_remaining; }
 
-    static get energy_full() { return Battery.instance.energy_full; }
     static get energyFull() { return Battery.instance.energy_full; }
+    static get energy_full() { return Battery.instance.energy_full; }
     static get ['energy-full']() { return Battery.instance.energy_full; }
 
-    static get energy_rate() { return Battery.instance.energy_rate; }
     static get energyRate() { return Battery.instance.energy_rate; }
+    static get energy_rate() { return Battery.instance.energy_rate; }
     static get ['energy-rate']() { return Battery.instance.energy_rate; }
 }

--- a/src/service/battery.ts
+++ b/src/service/battery.ts
@@ -23,6 +23,10 @@ class BatteryService extends Service {
             'charging': ['boolean'],
             'charged': ['boolean'],
             'icon-name': ['string'],
+            'time-remaining': ['float'],
+            'energy': ['float'],
+            'energy-full': ['float'],
+            'energy-rate': ['float'],
         });
     }
 
@@ -33,12 +37,20 @@ class BatteryService extends Service {
     private _charging = false;
     private _charged = false;
     private _iconName = 'battery-missing-symbolic';
+    private _timeRemaining = 0;
+    private _energy = 0.0;
+    private _energyFull = 0.0;
+    private _energyRate = 0.0;
 
     get available() { return this._available; }
     get percent() { return this._percent; }
     get charging() { return this._charging; }
     get charged() { return this._charged; }
     get icon_name() { return this._iconName; }
+    get time_remaining() { return this._timeRemaining; }
+    get energy() { return this._energy; }
+    get energy_full() { return this._energyFull; }
+    get energy_rate() { return this._energyRate; }
 
     constructor() {
         super();
@@ -71,11 +83,23 @@ class BatteryService extends Service {
             ? 'battery-level-100-charged-symbolic'
             : `battery-level-${level}${state}-symbolic`;
 
+        const timeRemaining = charged ? this._proxy.TimeToFull : this._proxy.TimeToEmpty;
+
+        const energy = this._proxy.Energy;
+
+        const energyFull = this._proxy.EnergyFull;
+
+        const energyRate = this._proxy.EnergyRate;
+
         this.updateProperty('available', true);
         this.updateProperty('icon-name', iconName);
         this.updateProperty('percent', percent);
         this.updateProperty('charging', charging);
         this.updateProperty('charged', charged);
+        this.updateProperty('time-remaining', timeRemaining);
+        this.updateProperty('energy', energy);
+        this.updateProperty('energy-full', energyFull);
+        this.updateProperty('energy-rate', energyRate);
         this.emit('changed');
     }
 }
@@ -92,8 +116,21 @@ export default class Battery {
     static get percent() { return Battery.instance.percent; }
     static get charging() { return Battery.instance.charging; }
     static get charged() { return Battery.instance.charged; }
+    static get energy() { return Battery.instance.energy; }
 
     static get iconName() { return Battery.instance.icon_name; }
     static get icon_name() { return Battery.instance.icon_name; }
     static get ['icon-name']() { return Battery.instance.icon_name; }
+
+    static get time_remaining() { return Battery.instance.time_remaining; }
+    static get timeRemaining() { return Battery.instance.time_remaining; }
+    static get ['time-remaining']() { return Battery.instance.time_remaining; }
+
+    static get energy_full() { return Battery.instance.energy_full; }
+    static get energyFull() { return Battery.instance.energy_full; }
+    static get ['energy-full']() { return Battery.instance.energy_full; }
+
+    static get energy_rate() { return Battery.instance.energy_rate; }
+    static get energyRate() { return Battery.instance.energy_rate; }
+    static get ['energy-rate']() { return Battery.instance.energy_rate; }
 }


### PR DESCRIPTION
This PR simply adds more properties to the Battery service. Now, it's possible to get
- `time-remaining` - Time in seconds until fully charged (if charging) or empty (if not charging)
- `energy` - Current energy in W
- `energy-full` - Capacity in W
- `energy-rate` - Drain rate in W (positive if not charging, negative if charging)

These properties are taken from [here](https://upower.freedesktop.org/docs/UPower.html) under `GetDisplayDevice()`