### PR TITLE
Applications: add setter to frequency

### DIFF
--- a/src/service/applications.ts
+++ b/src/service/applications.ts
@@ -25,7 +25,16 @@ class Application extends Service {
     _frequency: number;
 
     get app() { return this._app; }
+
     get frequency() { return this._frequency; }
+    set frequency(value) {
+        if (value < 0)
+            value = 0;
+
+        this._frequency = value;
+        this.emit('launched');
+    }
+
     get name() { return this._app.get_name(); }
     get desktop() { return this._app.get_id(); }
     get description() { return this._app.get_description(); }


### PR DESCRIPTION
I wanted to have a setter for frequency to be able to launch apps from the applauncher without using the `launch()` function, while still having the benefit of keeping track of frequency. 

I wasn't satisfied with the resolution of #50, so this is my take on it.

Basically, instead of doing `app.launch()`, I do this:
```js
Utils.exec(`hyprctl dispatch exec ${app.executable}`);
++app.frequency;
```