### PR TITLE
send mssages to hyprland IPC

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -2,7 +2,11 @@ import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 import Service from '../service.js';
 
+Gio._promisify(Gio.DataInputStream.prototype, 'read_upto_async');
 const HIS = GLib.getenv('HYPRLAND_INSTANCE_SIGNATURE');
+
+const socket = (path: string) => new Gio.SocketClient()
+    .connect(new Gio.UnixSocketAddress({ path }), null);
 
 export class Active extends Service {
     updateProperty(prop: string, value: unknown): void {
@@ -101,6 +105,7 @@ export class Hyprland extends Service {
     private _workspaces: Map<number, object>;
     private _clients: Map<string, object>;
     private _decoder = new TextDecoder();
+    private _encoder = new TextEncoder();
 
     get active() { return this._active; }
     get monitors() { return Array.from(this._monitors.values()); }
@@ -115,8 +120,6 @@ export class Hyprland extends Service {
         if (!HIS)
             console.error('Hyprland is not running');
 
-        Gio._promisify(Gio.DataInputStream.prototype, 'read_upto_async');
-
         super();
         this._active = new Actives();
         this._monitors = new Map();
@@ -128,10 +131,7 @@ export class Hyprland extends Service {
 
         this._watchSocket(new Gio.DataInputStream({
             close_base_stream: true,
-            base_stream: new Gio.SocketClient()
-                .connect(new Gio.UnixSocketAddress({
-                    path: `/tmp/hypr/${HIS}/.socket2.sock`,
-                }), null)
+            base_stream: socket(`/tmp/hypr/${HIS}/.socket2.sock`)
                 .get_input_stream(),
         }));
 
@@ -154,15 +154,17 @@ export class Hyprland extends Service {
     }
 
     async sendMessage(cmd: string) {
-        const connection = new Gio.SocketClient()
-            .connect(new Gio.UnixSocketAddress({
-                path: `/tmp/hypr/${HIS}/.socket.sock`,
-            }), null);
-        connection.get_output_stream().write((new TextEncoder()).encode(cmd), null);
+        const connection = socket(`/tmp/hypr/${HIS}/.socket.sock`);
+
+        connection
+            .get_output_stream()
+            .write(this._encoder.encode(cmd), null);
+
         const inputStream = new Gio.DataInputStream({
             close_base_stream: true,
             base_stream: connection.get_input_stream(),
         });
+
         return inputStream.read_upto_async('\x04', -1, 0, null)
             .then(result => {
                 const [response] = result as unknown as [string, number];


### PR DESCRIPTION
allows to send messages to the hyprland IPC, and therefore replacing the need of calling hyprctl in an exec.

adds an `sendMessage(cmd: string)`funtion to the Hyrpland service, which sends the given string to the ipc and returns the result.
a few examples:
```js
//get clients
const clients = await Hyprland.sendMessage("clients")
//get clients as json
const clients = await Hyprland.sendMessage("j/clients")
//open foot terminal
await Hyprland.sendMessage("dispatch exec foot")
//multiple messages grouped together
await Hyprland.sendMessage("[[BATCH]] keyword general:border_size 2; keyword general:gaps_out 20")
```

