### PR TITLE
add marks property to slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - add: cursor property
 - feat: window popup close on click away
 - add: config.onWindowToggled & config.onConfigParsed
+- add: marks property setter to slider #186
 
 ## Breaking Changes
 

--- a/src/widgets/slider.ts
+++ b/src/widgets/slider.ts
@@ -7,7 +7,7 @@ import Service from '../service.js';
 type EventHandler = (self: AgsSlider, event: Gdk.Event) => void | unknown;
 const positions = ['left', 'right', 'top', 'bottom'] as const;
 type Position = typeof positions[number];
-type Mark = [number, string, Position];
+type Mark = [number, string?, Position?];
 export interface SliderProps extends BaseProps<AgsSlider>, Gtk.Scale.ConstructorProperties {
     on_change?: EventHandler,
     value?: number
@@ -109,7 +109,6 @@ export default class AgsSlider extends AgsWidget(Gtk.Scale) {
                 positionType = positions.findIndex(p => p === mark[2]);
             this.add_mark(mark[0], positionType, mark[1] || '');
         });
-
         this.notify('marks');
     }
 

--- a/src/widgets/slider.ts
+++ b/src/widgets/slider.ts
@@ -7,7 +7,7 @@ import Service from '../service.js';
 type EventHandler = (self: AgsSlider, event: Gdk.Event) => void | unknown;
 const positions = ['left', 'right', 'top', 'bottom'] as const;
 type Position = typeof positions[number];
-type Mark = [number, string?, Position?];
+type Mark = [number, string?, Position?] | number;
 export interface SliderProps extends BaseProps<AgsSlider>, Gtk.Scale.ConstructorProperties {
     on_change?: EventHandler,
     value?: number
@@ -28,7 +28,6 @@ export default class AgsSlider extends AgsWidget(Gtk.Scale) {
                 'min': Service.pspec('min', 'double', 'rw'),
                 'max': Service.pspec('max', 'double', 'rw'),
                 'step': Service.pspec('step', 'double', 'rw'),
-                'marks': Service.pspec('marks', 'jsobject', 'rw'),
                 'on-change': Service.pspec('on-change', 'jsobject', 'rw'),
             },
         }, this);
@@ -104,13 +103,18 @@ export default class AgsSlider extends AgsWidget(Gtk.Scale) {
     set marks(marks: Mark[]) {
         this.clear_marks();
         marks.forEach(mark => {
-            let positionType = Gtk.PositionType.TOP;
-            if (mark[2])
-                positionType = positions.findIndex(p => p === mark[2]);
-            this.add_mark(mark[0], positionType, mark[1] || '');
+            if (typeof mark === 'number') {
+                this.add_mark(mark, Gtk.PositionType.TOP, '');
+            }
+            else {
+                let positionType = Gtk.PositionType.TOP;
+                if (mark[2])
+                    positionType = positions.findIndex(p => p === mark[2]);
+                this.add_mark(mark[0], positionType, mark[1] || '');
+            }
         });
-        this.notify('marks');
     }
+
 
     get dragging() { return this._get('dragging'); }
     set dragging(dragging: boolean) { this._set('dragging', dragging); }

--- a/src/widgets/slider.ts
+++ b/src/widgets/slider.ts
@@ -5,13 +5,16 @@ import Gdk from 'gi://Gdk?version=3.0';
 import Service from '../service.js';
 
 type EventHandler = (self: AgsSlider, event: Gdk.Event) => void | unknown;
-
+const positions = ['left', 'right', 'top', 'bottom'] as const;
+type Position = typeof positions[number];
+type Mark = [number, string, Position];
 export interface SliderProps extends BaseProps<AgsSlider>, Gtk.Scale.ConstructorProperties {
     on_change?: EventHandler,
     value?: number
     min?: number
     max?: number
     step?: number
+    marks?: Mark[]
 }
 
 export default class AgsSlider extends AgsWidget(Gtk.Scale) {
@@ -25,6 +28,7 @@ export default class AgsSlider extends AgsWidget(Gtk.Scale) {
                 'min': Service.pspec('min', 'double', 'rw'),
                 'max': Service.pspec('max', 'double', 'rw'),
                 'step': Service.pspec('step', 'double', 'rw'),
+                'marks': Service.pspec('marks', 'jsobject', 'rw'),
                 'on-change': Service.pspec('on-change', 'jsobject', 'rw'),
             },
         }, this);
@@ -35,6 +39,7 @@ export default class AgsSlider extends AgsWidget(Gtk.Scale) {
         min = 0,
         max = 1,
         step = 0.01,
+        marks = [],
         ...rest
     }: SliderProps = {}) {
         super({
@@ -46,6 +51,8 @@ export default class AgsSlider extends AgsWidget(Gtk.Scale) {
                 value: value,
             }),
         });
+
+        this.marks = marks;
 
         this.adjustment.connect('notify::value', (_, event: Gdk.Event) => {
             if (!this.dragging)
@@ -92,6 +99,18 @@ export default class AgsSlider extends AgsWidget(Gtk.Scale) {
 
         this.adjustment.step_increment = step;
         this.notify('step');
+    }
+
+    set marks(marks: Mark[]) {
+        this.clear_marks();
+        marks.forEach(mark => {
+            let positionType = Gtk.PositionType.TOP;
+            if (mark[2])
+                positionType = positions.findIndex(p => p === mark[2]);
+            this.add_mark(mark[0], positionType, mark[1] || '');
+        });
+
+        this.notify('marks');
     }
 
     get dragging() { return this._get('dragging'); }


### PR DESCRIPTION
add a marks Property to the Slider widget, making it easier to add marks. The intention is to replace the need of calling `slider.add_mark(value, position, markup)`

Syntax:
```js
Widget.Slider({
    marks: [
        //[value, markup, position]
        [1, 'one', 'top'],
        [2, 'two']
    ]
})
```

- value: type number: the value, where on the slider the mark should be placed
- markup: type string: the text, which should be placed at the mark (optional, defaults to '')
- position: type 'left'|'right'|'top'|'bottom': the placement of the mark relative to the slider (optional, defaults to top or left, depending on orientation)

note, that i swapped the parameters, as i think markup is probably used more often than position, and therefore position can be omitted in the array.

adds a `notify::marks`signal.

I didn't find a way to get a list of the current marks from the Gtk.Scale widget, so reading marks, won't be possible unless we store them ourself, which i'm not sure we should do.

if a slider should have no labels and the marks should be placed at the top, this would have to be done:
```js
Widget.Slider({
    marks: [
        [1], [2], [3], [4]
    ]
})
```
maybe marks should also accept `number[]`, using the default values for markup and position? So this could be used instead:
```js
Widget.Slider({
    marks: [1, 2, 3, 4]
})
```