### PR TITLE
Feature: Add `fetch` function to utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - add: Applications.reload
 - add: Utils.idle
 - use GLib.shell_parse_argv on Utils.execAsync
+- feat: Utils.fetch
 
 ## Breaking Changes
 - update: Hyprland.active.monitor to be an object

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
     dontBuild = true;
 
-    npmDepsHash = "sha256-QlZ0DNflreSibIP5sN8ZtevETVkNPJGaiIPrPhBcTKs=";
+    npmDepsHash = "sha256-1CyVl0DAKT4difSjG0SX/aQscgXrpotMPUZo3f3Xf58=";
 
     installPhase = ''
       mkdir $out

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,6 +19,7 @@
 , networkmanager
 , libdbusmenu-gtk3
 , gvfs
+, libsoup_3
 , extraPackages ? []
 }:
 
@@ -41,7 +42,7 @@ stdenv.mkDerivation {
 
     dontBuild = true;
 
-    npmDepsHash = "sha256-y5kIMnZSU4IV2oCitcXFc6y7oVJxnLCzkA1lvSOrc/k=";
+    npmDepsHash = "sha256-QlZ0DNflreSibIP5sN8ZtevETVkNPJGaiIPrPhBcTKs=";
 
     installPhase = ''
       mkdir $out
@@ -80,6 +81,7 @@ stdenv.mkDerivation {
     networkmanager
     libdbusmenu-gtk3
     gvfs
+    libsoup_3
   ] ++ extraPackages;
 
   meta = with lib; {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@girs/gtk-3.0": "^3.24.39-3.2.2",
                 "@girs/gvc-1.0": "^1.0.0-3.1.0",
                 "@girs/nm-1.0": "^1.43.1-3.1.0",
+                "@girs/soup-3.0": "^3.4.4-3.2.5",
                 "@typescript-eslint/eslint-plugin": "^5.33.0",
                 "@typescript-eslint/parser": "^5.33.0",
                 "eslint": "^8.42.0"
@@ -449,6 +450,49 @@
                 "@girs/glib-2.0": "^2.78.0-3.2.6",
                 "@girs/gobject-2.0": "^2.78.0-3.2.6",
                 "@girs/harfbuzz-0.0": "^8.2.1-3.2.6"
+            }
+        },
+        "node_modules/@girs/soup-3.0": {
+            "version": "3.4.4-3.2.5",
+            "resolved": "https://registry.npmjs.org/@girs/soup-3.0/-/soup-3.0-3.4.4-3.2.5.tgz",
+            "integrity": "sha512-uyXZlGnC3IRcRJVO2+ctKVWitj0rTegitGmgGoGuWUIaONHrb4SK96is082x9jXlzEvzOKaP0oZy12fOoEsTEQ==",
+            "dev": true,
+            "dependencies": {
+                "@girs/gio-2.0": "^2.78.0-3.2.5",
+                "@girs/gjs": "^3.2.5",
+                "@girs/glib-2.0": "^2.78.0-3.2.5",
+                "@girs/gobject-2.0": "^2.78.0-3.2.5"
+            }
+        },
+        "node_modules/@girs/soup-3.0/node_modules/@girs/gio-2.0": {
+            "version": "2.78.0-3.2.5",
+            "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.78.0-3.2.5.tgz",
+            "integrity": "sha512-8QVn6rydZuevkkLbLTrURs9bHD8vbvfFZMzR/5iPsTrv6d5wCewUmMxiKEcMicnJmOIhBitu1ZboP8sljht90Q==",
+            "dev": true,
+            "dependencies": {
+                "@girs/gjs": "^3.2.5",
+                "@girs/glib-2.0": "^2.78.0-3.2.5",
+                "@girs/gobject-2.0": "^2.78.0-3.2.5"
+            }
+        },
+        "node_modules/@girs/soup-3.0/node_modules/@girs/glib-2.0": {
+            "version": "2.78.0-3.2.5",
+            "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.78.0-3.2.5.tgz",
+            "integrity": "sha512-VIfgmRPixvxh9i2FPE0ctvWgHMuzWkXjERtG4G8uxnBdH7HAL6+hcEFFYyn1JrkBm4XFVvikyUZYPPoahlDsaQ==",
+            "dev": true,
+            "dependencies": {
+                "@girs/gjs": "^3.2.5",
+                "@girs/gobject-2.0": "^2.78.0-3.2.5"
+            }
+        },
+        "node_modules/@girs/soup-3.0/node_modules/@girs/gobject-2.0": {
+            "version": "2.78.0-3.2.5",
+            "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.78.0-3.2.5.tgz",
+            "integrity": "sha512-xjplH7Slij+l2/QFO9MYLoe+lHtHsQvZVIccGVOdZtaVMqL6wq3J2JH9ul6czf5EFnApuhN2pXFeE77Jacwduw==",
+            "dev": true,
+            "dependencies": {
+                "@girs/gjs": "^3.2.5",
+                "@girs/glib-2.0": "^2.78.0-3.2.5"
             }
         },
         "node_modules/@girs/xlib-2.0": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@girs/gtk-3.0": "^3.24.39-3.2.2",
                 "@girs/gvc-1.0": "^1.0.0-3.1.0",
                 "@girs/nm-1.0": "^1.43.1-3.1.0",
-                "@girs/soup-3.0": "^3.4.4-3.2.5",
+                "@girs/soup-3.0": "^3.4.4-3.2.6",
                 "@typescript-eslint/eslint-plugin": "^5.33.0",
                 "@typescript-eslint/parser": "^5.33.0",
                 "eslint": "^8.42.0"
@@ -453,46 +453,15 @@
             }
         },
         "node_modules/@girs/soup-3.0": {
-            "version": "3.4.4-3.2.5",
-            "resolved": "https://registry.npmjs.org/@girs/soup-3.0/-/soup-3.0-3.4.4-3.2.5.tgz",
-            "integrity": "sha512-uyXZlGnC3IRcRJVO2+ctKVWitj0rTegitGmgGoGuWUIaONHrb4SK96is082x9jXlzEvzOKaP0oZy12fOoEsTEQ==",
+            "version": "3.4.4-3.2.6",
+            "resolved": "https://registry.npmjs.org/@girs/soup-3.0/-/soup-3.0-3.4.4-3.2.6.tgz",
+            "integrity": "sha512-5G9alsn+JG2yoCNkesKheAiPN8WQJgvOoTYQCf4bY+KVHPvHEf5X5y4gTR+wFP0xNEaoRM2LR9VruAxyOErv3A==",
             "dev": true,
             "dependencies": {
-                "@girs/gio-2.0": "^2.78.0-3.2.5",
-                "@girs/gjs": "^3.2.5",
-                "@girs/glib-2.0": "^2.78.0-3.2.5",
-                "@girs/gobject-2.0": "^2.78.0-3.2.5"
-            }
-        },
-        "node_modules/@girs/soup-3.0/node_modules/@girs/gio-2.0": {
-            "version": "2.78.0-3.2.5",
-            "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.78.0-3.2.5.tgz",
-            "integrity": "sha512-8QVn6rydZuevkkLbLTrURs9bHD8vbvfFZMzR/5iPsTrv6d5wCewUmMxiKEcMicnJmOIhBitu1ZboP8sljht90Q==",
-            "dev": true,
-            "dependencies": {
-                "@girs/gjs": "^3.2.5",
-                "@girs/glib-2.0": "^2.78.0-3.2.5",
-                "@girs/gobject-2.0": "^2.78.0-3.2.5"
-            }
-        },
-        "node_modules/@girs/soup-3.0/node_modules/@girs/glib-2.0": {
-            "version": "2.78.0-3.2.5",
-            "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.78.0-3.2.5.tgz",
-            "integrity": "sha512-VIfgmRPixvxh9i2FPE0ctvWgHMuzWkXjERtG4G8uxnBdH7HAL6+hcEFFYyn1JrkBm4XFVvikyUZYPPoahlDsaQ==",
-            "dev": true,
-            "dependencies": {
-                "@girs/gjs": "^3.2.5",
-                "@girs/gobject-2.0": "^2.78.0-3.2.5"
-            }
-        },
-        "node_modules/@girs/soup-3.0/node_modules/@girs/gobject-2.0": {
-            "version": "2.78.0-3.2.5",
-            "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.78.0-3.2.5.tgz",
-            "integrity": "sha512-xjplH7Slij+l2/QFO9MYLoe+lHtHsQvZVIccGVOdZtaVMqL6wq3J2JH9ul6czf5EFnApuhN2pXFeE77Jacwduw==",
-            "dev": true,
-            "dependencies": {
-                "@girs/gjs": "^3.2.5",
-                "@girs/glib-2.0": "^2.78.0-3.2.5"
+                "@girs/gio-2.0": "^2.78.0-3.2.6",
+                "@girs/gjs": "^3.2.6",
+                "@girs/glib-2.0": "^2.78.0-3.2.6",
+                "@girs/gobject-2.0": "^2.78.0-3.2.6"
             }
         },
         "node_modules/@girs/xlib-2.0": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "typescript": "^5.1.0"
     },
     "devDependencies": {
+        "@girs/soup-3.0": "^3.4.4-3.2.5",
         "@girs/dbusmenugtk3-0.4": "^0.4.0-3.2.0",
         "@girs/gtk-3.0": "^3.24.39-3.2.2",
         "@girs/gvc-1.0": "^1.0.0-3.1.0",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
         "typescript": "^5.1.0"
     },
     "devDependencies": {
-        "@girs/soup-3.0": "^3.4.4-3.2.5",
         "@girs/dbusmenugtk3-0.4": "^0.4.0-3.2.0",
         "@girs/gtk-3.0": "^3.24.39-3.2.2",
         "@girs/gvc-1.0": "^1.0.0-3.1.0",
         "@girs/nm-1.0": "^1.43.1-3.1.0",
+        "@girs/soup-3.0": "^3.4.4-3.2.6",
         "@typescript-eslint/eslint-plugin": "^5.33.0",
         "@typescript-eslint/parser": "^5.33.0",
         "eslint": "^8.42.0"

--- a/src/com.github.Aylur.ags.src.gresource.xml
+++ b/src/com.github.Aylur.ags.src.gresource.xml
@@ -53,5 +53,6 @@
     <file>utils/exec.js</file>
     <file>utils/file.js</file>
     <file>utils/timeout.js</file>
+    <file>utils/fetch.js</file>
   </gresource>
 </gresources>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import * as Exec from './utils/exec.js';
 import * as File from './utils/file.js';
 import * as Etc from './utils/etc.js';
 import * as Timeout from './utils/timeout.js';
+import * as Fetch from './utils/fetch.js';
 
 export const USER = GLib.get_user_name();
 export const CACHE_DIR = `${GLib.get_user_cache_dir()}/${pkg.name.split('.').pop()}`;
@@ -26,9 +27,12 @@ export const bulkDisconnect = Etc.bulkDisconnect;
 export const ensureDirectory = Etc.ensureDirectory;
 export const lookUpIcon = Etc.lookUpIcon;
 
+export const fetch = Fetch.fetch;
+
 export default {
     exec, execAsync, subprocess,
     readFile, readFileAsync, writeFile, monitorFile,
     timeout, interval, idle,
     loadInterfaceXML, bulkConnect, bulkDisconnect, ensureDirectory, lookUpIcon,
+    fetch,
 };

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,67 @@
+// code mostly take from https://github.com/sonnyp/troll
+
+import Soup from 'gi://Soup?version=3.0';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+
+Gio._promisify(Soup.Session.prototype, 'send_async');
+Gio._promisify(Gio.MemoryOutputStream.prototype, 'splice_async');
+
+export type FetchOptions = {
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+    body?: string;
+    headers?: Record<string, string>;
+};
+
+export async function fetch(url: string, options: FetchOptions = {}) {
+    const session = new Soup.Session();
+
+    const message = new Soup.Message({
+        method: options.method || 'GET',
+        uri: GLib.Uri.parse(url, GLib.UriFlags.NONE),
+    });
+
+    if (options.headers) {
+        for (const key of Object.keys(options.headers))
+            message.get_request_headers().append(key, options.headers[key]);
+    }
+
+    if (typeof options.body === 'string') {
+        message.set_request_body_from_bytes(null,
+            new GLib.Bytes((new TextEncoder).encode(options.body)));
+    }
+
+    const inputStream = await session.send_async(message, 0, null);
+    const { status_code, reason_phrase } = message;
+    const ok = status_code >= 200 && status_code < 300;
+
+    return {
+        status: status_code,
+        statusText: reason_phrase,
+        ok,
+        type: 'basic',
+        async json() {
+            const text = await this.text();
+            return JSON.parse(text);
+        },
+        async text() {
+            const gBytes = await this.gBytes();
+            return new TextDecoder().decode(gBytes.toArray());
+        },
+        async arrayBuffer() {
+            const gBytes = await this.gBytes();
+            return gBytes.toArray().buffer;
+        },
+        async gBytes() {
+            const outputStream = Gio.MemoryOutputStream.new_resizable();
+
+            await outputStream.splice_async(inputStream,
+                Gio.OutputStreamSpliceFlags.CLOSE_TARGET |
+                Gio.OutputStreamSpliceFlags.CLOSE_SOURCE,
+                GLib.PRIORITY_DEFAULT,
+                null);
+
+            return outputStream.steal_as_bytes();
+        },
+    };
+}


### PR DESCRIPTION
As already discussed on the Discord, here is my submission for a asynchronous fetch function, that will provide the ability (for now) to add `POST` as well as `GET` reqeuests.

My design considerations are mostly, that types should do essentially most of the Documentation and i think it does a pretty good job.

An example usage of this function would be:
```ts
import * as Utils from 'resource:///com/github/Aylur/ags/utils.js';

const options = {
  method: 'GET',
  headers: null,
};

Utils.fetch('http://wttr.in/?format=3', options)
  .then(res => {
    res = "[redacted]" + res.substring(res.indexOf(':'));
    console.log(res);
  })
  .catch(err => console.error(err));
```

This example will just print something like:
`Gjs-Console-Message: 16:32:47.627: [redacted]: 🌨  +1°C` to the console.