### PR TITLE
adding cache option for cover art

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ interface Config {
     notificationPopupTimeout: number
     notificationForceTimeout: boolean
     cacheNotificationActions: boolean
+    cacheCoverArt: boolean
     closeWindowDelay: { [key: string]: number }
     maxStreamVolume: number
     onWindowToggled?: (windowName: string, visible: boolean) => void,
@@ -185,6 +186,7 @@ export class App extends Gtk.Application {
             config.notificationForceTimeout ||= false;
             config.maxStreamVolume ||= 1.5;
             config.cacheNotificationActions ||= false;
+            config.cacheCoverArt ??= true;
             this._config = config;
 
             if (!config) {

--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -1,5 +1,6 @@
 import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
+import App from '../app.js';
 import Service from '../service.js';
 import { ensureDirectory, timeout } from '../utils.js';
 import { CACHE_DIR } from '../utils.js';
@@ -178,7 +179,7 @@ export class MprisPlayer extends Service {
     }
 
     private _cacheCoverArt() {
-        if (this._trackCoverUrl === '')
+        if (!App.config.cacheCoverArt || this._trackCoverUrl === '')
             return;
 
         this._coverPath = MEDIA_CACHE_PATH + '/' +
@@ -192,7 +193,6 @@ export class MprisPlayer extends Service {
             Gio.File.new_for_path(this._coverPath),
             Gio.FileCopyFlags.OVERWRITE,
             GLib.PRIORITY_DEFAULT,
-            // @ts-expect-error
             null, null, (source: Gio.File, result: Gio.AsyncResult) => {
                 try {
                     source.copy_finish(result);


### PR DESCRIPTION
Adds the ` cacheCoverArt` config option.
Setting this to false will prevent downloading the cover Art from `trackCoverUrl` and saving it to the cache, it will also prevent the `cover-path` signal from emitting.
Setting it to true will result in the same behavior as currently.
Defaults to true if not specified to maintain compatibility.