### PR TITLE
CI: nix binary cache

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -12,11 +12,13 @@ jobs:
         submodules: recursive
 
     - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: cachix/cachix-action@v12
-        with:
-          name: ags
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      with:
+        logger: pretty
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: cachix/cachix-action@v12
+      with:
+        name: ags
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: Build ags
       run: nix build --print-build-logs

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,22 @@
+name: Binary Cache
+
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  nix:
+    name: "Build"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
+        with:
+          name: ags
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - name: Build ags
+      run: nix build --print-build-logs


### PR DESCRIPTION
This should automatically build and cache the builds and upload them to `ags.cachix.org`.

Needs `CACHIX_AUTH_TOKEN` to be set.