### PR TITLE
Update starter configuration

### DIFF
--- a/example/simple-bar/config.js
+++ b/example/simple-bar/config.js
@@ -182,7 +182,7 @@ const Bar = ({ monitor } = {}) => Widget.Window({
     className: 'bar',
     monitor,
     anchor: ['top', 'left', 'right'],
-    exclusive: true,
+    exclusivity: 'exclusive',
     child: Widget.CenterBox({
         startWidget: Left(),
         centerWidget: Center(),

--- a/example/starter-config/config.js
+++ b/example/starter-config/config.js
@@ -9,7 +9,7 @@ const Bar = (/** @type {number} */ monitor) => Widget.Window({
     monitor,
     name: `bar${monitor}`,
     anchor: ['top', 'left', 'right'],
-    exclusive: true,
+    exclusivity: 'exclusive',
     child: Widget.CenterBox({
         start_widget: Widget.Label({
             hpack: 'center',

--- a/example/starter-config/package.json
+++ b/example/starter-config/package.json
@@ -13,9 +13,6 @@
         "@girs/gobject-2.0": "^2.76.1-3.2.3",
         "@girs/gtk-3.0": "^3.24.39-3.2.2",
         "@girs/gvc-1.0": "^1.0.0-3.1.0",
-        "@girs/nm-1.0": "^1.43.1-3.1.0",
-        "@typescript-eslint/eslint-plugin": "^5.33.0",
-        "@typescript-eslint/parser": "^5.33.0",
-        "eslint": "^8.44.0"
+        "@girs/nm-1.0": "^1.43.1-3.1.0"
     }
 }


### PR DESCRIPTION
This PR:
1. Removes the unused linting dependencies from `starter-config`. `typescript-eslint` isn't needed since the sample has no TypeScript files, and `eslint` is a bit too much for such a minimal setup.
2. Replaces `exclusive` by `exclusivity`, since the former has been deprecated.