### PR TITLE
fix(entry): emit on_change when pressing backspace

### DIFF
--- a/src/widgets/entry.ts
+++ b/src/widgets/entry.ts
@@ -25,6 +25,7 @@ export default class AgsEntry extends AgsWidget(Gtk.Entry) {
 
         this.connect('activate', () => this.on_accept?.(this));
         this.connect('notify::text', () => this.on_change?.(this));
+        this.connect('backspace', () => this.on_change?.(this));
     }
 
     get on_accept() { return this._get('on-accept'); }


### PR DESCRIPTION
I noticed entry widgets didn't update when pressing backspace so I simply connected to the `backspace` signal to call `on_change`.