### PR TITLE
fix chaining of transform function

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -31,7 +31,7 @@ export class Binding<
 
     transform<T>(fn: (v: Return) => T) {
         const bind = new Binding<Emitter, Prop, T>(this.emitter, this.prop);
-        const prev = bind.transformFn;
+        const prev = this.transformFn;
         // @ts-expect-error
         bind.transformFn = (v: Return) => fn(prev(v));
         return bind;


### PR DESCRIPTION
something like
```js
Mpris.bind('players').transform(players => players[0]).transform(player => player.name)
```
didn't work, only the second transform function was applied. This is fixed by this PR