### PR TITLE
add url params to fetch

### DIFF
--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -11,10 +11,16 @@ export type FetchOptions = {
     method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
     body?: string;
     headers?: Record<string, string>;
+    params?: Record<string, string>;
 };
 
 export async function fetch(url: string, options: FetchOptions = {}) {
     const session = new Soup.Session();
+
+    if (options.params) {
+        url += '?' + Object.entries(options.params).map(([k, v]) =>
+            `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+    }
 
     const message = new Soup.Message({
         method: options.method || 'GET',

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -33,8 +33,6 @@ export async function fetch(url: string, options: FetchOptions = {}) {
             .join('&');
     }
 
-    print(url)
-
     const message = new Soup.Message({
         method: options.method || 'GET',
         uri: GLib.Uri.parse(url, GLib.UriFlags.NONE),

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -11,16 +11,29 @@ export type FetchOptions = {
     method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
     body?: string;
     headers?: Record<string, string>;
-    params?: Record<string, string>;
+    params?: Record<string, any>;
 };
 
 export async function fetch(url: string, options: FetchOptions = {}) {
     const session = new Soup.Session();
 
     if (options.params) {
-        url += '?' + Object.entries(options.params).map(([k, v]) =>
-            `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+        url += '?' + Object.entries(options.params)
+            .map(([key, value]) => {
+                if (Array.isArray(value)) {
+                    return value.map(val =>
+                        `${encodeURIComponent(key)}=${encodeURIComponent(val)}`).join('&');
+                } else if (typeof value === 'object') {
+                    return `${encodeURIComponent(key)}=${encodeURIComponent(
+                        JSON.stringify(value))}`;
+                } else {
+                    return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+                }
+            })
+            .join('&');
     }
+
+    print(url)
 
     const message = new Soup.Message({
         method: options.method || 'GET',


### PR DESCRIPTION
this PR adds a params to the options of fetch. These two are equivalent:
```js
Utils.fetch('http://wttr.in/?format=3')
const options = {
  params: { format: 3 }
}
Utils.fetch('http://wttr.in/', options)
```
This is especially useful, if the params are created dynamically, as the users won't have to handle encoding themself.
This is not part of the web fetch api, but i think this is still useful, as unlike the web, there is no `URLSearchParams`in gjs.
I did some testing on this and this is compliant with the url scheme.