### PR TITLE
feat(widgets): add child and overlay props

### DIFF
--- a/src/widgets/box.ts
+++ b/src/widgets/box.ts
@@ -20,6 +20,11 @@ export default class AgsBox extends AgsWidget(Gtk.Box) {
         super(props as Gtk.Box.ConstructorProperties);
     }
 
+    get child() { return this.children[0]; }
+    set child(child: Gtk.Widget) {
+        this.children = [child];
+    }
+
     get children() { return this.get_children(); }
     set children(children: Gtk.Widget[]) {
         const newChildren = children || [];

--- a/src/widgets/overlay.ts
+++ b/src/widgets/overlay.ts
@@ -4,6 +4,7 @@ import Gtk from 'gi://Gtk?version=3.0';
 export type OverlayProps = BaseProps<AgsOverlay, Gtk.Overlay.ConstructorProperties & {
     pass_through?: boolean
     overlays?: Gtk.Widget[]
+    overlay?: Gtk.Widget
 }>
 
 export default class AgsOverlay extends AgsWidget(Gtk.Overlay) {
@@ -12,6 +13,7 @@ export default class AgsOverlay extends AgsWidget(Gtk.Overlay) {
             properties: {
                 'pass-through': ['boolean', 'rw'],
                 'overlays': ['jsobject', 'rw'],
+                'overlay': ['jsobject', 'rw'],
             },
         });
     }
@@ -33,6 +35,12 @@ export default class AgsOverlay extends AgsWidget(Gtk.Overlay) {
         this._set('pass-through', passthrough);
         this._updatePassThrough();
         this.notify('pass-through');
+    }
+
+    get overlay() { return this.overlays[0]; }
+    set overlay(overlay: Gtk.Widget) {
+        this.overlays = [overlay];
+        this.notify('overlay');
     }
 
     get overlays() {

--- a/src/widgets/overlay.ts
+++ b/src/widgets/overlay.ts
@@ -36,7 +36,7 @@ export default class AgsOverlay extends AgsWidget(Gtk.Overlay) {
     }
 
     get overlays() {
-        return this.get_children().filter(ch => ch === this.child);
+        return this.get_children().filter(ch => ch !== this.child);
     }
 
     set overlays(overlays: Gtk.Widget[]) {


### PR DESCRIPTION
This PR adds the `overlay` property that allows setting and getting a single widget as an overlay instead of dealing with an array of widgets.

For feature parity, I decided to overwrite the `child` prop on `Box` to allow doing the same thing.

I also fixed a bug where the `overlays` getter would return the widget's child instead of all the overlays.