### PR TITLE
allow circler progress to draw arc

### DIFF
--- a/src/widgets/circularprogress.ts
+++ b/src/widgets/circularprogress.ts
@@ -72,7 +72,6 @@ export default class AgsCircularProgress extends AgsWidget(Gtk.Bin) {
     }
 
     get end_at() { return this._get('end-at') || this.start_at; }
-    // Check if end_at is not provided and calculate it to complete a full circle
     set end_at(value: number) {
         if (this.end_at === value)
             return;
@@ -188,17 +187,31 @@ export default class AgsCircularProgress extends AgsWidget(Gtk.Bin) {
         }
 
         const to = this._toRadian(rangedValue);
+        let startAngle, endAngle;
+        let backgroundStart, backgroundEnd;
+
+        if (this.inverted) {
+            startAngle = this._toRadian(360) - to;
+            endAngle = this._toRadian(360) - from;
+            backgroundStart = this._toRadian(360) - endDraw;
+            backgroundEnd = this._toRadian(360) - from;
+        } else {
+            startAngle = from;
+            endAngle = to;
+            backgroundStart = from;
+            backgroundEnd = endDraw;
+        }
 
         // Draw background
         cr.setSourceRGBA(bg.red, bg.green, bg.blue, bg.alpha);
-        cr.arc(center.x, center.y, radius, from, endDraw);
+        cr.arc(center.x, center.y, radius, backgroundStart, backgroundEnd);
 
         cr.setLineWidth(bgStroke);
         cr.stroke();
 
         // Draw progress
         cr.setSourceRGBA(fg.red, fg.green, fg.blue, fg.alpha);
-        cr.arc(center.x, center.y, radius, this.inverted ? to : from, this.inverted ? from : to);
+        cr.arc(center.x, center.y, radius, startAngle, endAngle);
         cr.setLineWidth(fgStroke);
         cr.stroke();
 

--- a/src/widgets/circularprogress.ts
+++ b/src/widgets/circularprogress.ts
@@ -168,15 +168,15 @@ export default class AgsCircularProgress extends AgsWidget(Gtk.Bin) {
         const radius = Math.min(width, height) / 2.0 - Math.max(bgStroke, fgStroke) / 2.0;
         const center = { x: width / 2, y: height / 2 };
 
+        const startBackground = this._toRadian(this.start_at);
+        let endBackground = this._toRadian(this.end_at);
         let rangedValue = this.value + this.start_at;
-        const calculatedStartAngle = this._toRadian(this.start_at);
-        let calculatedEndAngle = this._toRadian(this.end_at);
 
         const isCircle = this._isFullCircle(this.start_at, this.end_at);
 
         if (isCircle) {
             // Redefine endDraw in radius to create an accurate full circle
-            calculatedEndAngle = calculatedStartAngle + 2 * Math.PI;
+            endBackground = startBackground + 2 * Math.PI;
         } else {
             // Range the value for the arc shape
             rangedValue = this._mapArcValueToRange(
@@ -187,19 +187,14 @@ export default class AgsCircularProgress extends AgsWidget(Gtk.Bin) {
         }
 
         const to = this._toRadian(rangedValue);
-        let startBackground, endBackground;
         let startProgress, endProgress;
 
         if (this.inverted) {
-            startProgress = this._toRadian(360) - to;
-            endProgress = this._toRadian(360) - calculatedStartAngle;
-            startBackground = this._toRadian(360) - calculatedEndAngle;
-            endBackground = this._toRadian(360) - calculatedStartAngle;
+            startProgress = (2 * Math.PI - to) - startBackground;
+            endProgress = (2 * Math.PI - startBackground) - startBackground;
         } else {
-            startProgress = calculatedStartAngle;
+            startProgress = startBackground;
             endProgress = to;
-            startBackground = calculatedStartAngle;
-            endBackground = calculatedEndAngle;
         }
 
         // Draw background
@@ -218,8 +213,8 @@ export default class AgsCircularProgress extends AgsWidget(Gtk.Bin) {
         // Draw rounded ends
         if (this.rounded) {
             const start = {
-                x: center.x + Math.cos(calculatedStartAngle) * radius,
-                y: center.y + Math.sin(calculatedStartAngle) * radius,
+                x: center.x + Math.cos(startBackground) * radius,
+                y: center.y + Math.sin(startBackground) * radius,
             };
             const end = {
                 x: center.x + Math.cos(to) * radius,

--- a/src/widgets/circularprogress.ts
+++ b/src/widgets/circularprogress.ts
@@ -168,15 +168,15 @@ export default class AgsCircularProgress extends AgsWidget(Gtk.Bin) {
         const radius = Math.min(width, height) / 2.0 - Math.max(bgStroke, fgStroke) / 2.0;
         const center = { x: width / 2, y: height / 2 };
 
-        const from = this._toRadian(this.start_at);
         let rangedValue = this.value + this.start_at;
-        let endDraw = this._toRadian(this.end_at);
+        const calculatedStartAngle = this._toRadian(this.start_at);
+        let calculatedEndAngle = this._toRadian(this.end_at);
 
         const isCircle = this._isFullCircle(this.start_at, this.end_at);
 
         if (isCircle) {
             // Redefine endDraw in radius to create an accurate full circle
-            endDraw = from + 2 * Math.PI;
+            calculatedEndAngle = calculatedStartAngle + 2 * Math.PI;
         } else {
             // Range the value for the arc shape
             rangedValue = this._mapArcValueToRange(
@@ -187,39 +187,39 @@ export default class AgsCircularProgress extends AgsWidget(Gtk.Bin) {
         }
 
         const to = this._toRadian(rangedValue);
-        let startAngle, endAngle;
-        let backgroundStart, backgroundEnd;
+        let startBackground, endBackground;
+        let startProgress, endProgress;
 
         if (this.inverted) {
-            startAngle = this._toRadian(360) - to;
-            endAngle = this._toRadian(360) - from;
-            backgroundStart = this._toRadian(360) - endDraw;
-            backgroundEnd = this._toRadian(360) - from;
+            startProgress = this._toRadian(360) - to;
+            endProgress = this._toRadian(360) - calculatedStartAngle;
+            startBackground = this._toRadian(360) - calculatedEndAngle;
+            endBackground = this._toRadian(360) - calculatedStartAngle;
         } else {
-            startAngle = from;
-            endAngle = to;
-            backgroundStart = from;
-            backgroundEnd = endDraw;
+            startProgress = calculatedStartAngle;
+            endProgress = to;
+            startBackground = calculatedStartAngle;
+            endBackground = calculatedEndAngle;
         }
 
         // Draw background
         cr.setSourceRGBA(bg.red, bg.green, bg.blue, bg.alpha);
-        cr.arc(center.x, center.y, radius, backgroundStart, backgroundEnd);
+        cr.arc(center.x, center.y, radius, startBackground, endBackground);
 
         cr.setLineWidth(bgStroke);
         cr.stroke();
 
         // Draw progress
         cr.setSourceRGBA(fg.red, fg.green, fg.blue, fg.alpha);
-        cr.arc(center.x, center.y, radius, startAngle, endAngle);
+        cr.arc(center.x, center.y, radius, startProgress, endProgress);
         cr.setLineWidth(fgStroke);
         cr.stroke();
 
         // Draw rounded ends
         if (this.rounded) {
             const start = {
-                x: center.x + Math.cos(from) * radius,
-                y: center.y + Math.sin(from) * radius,
+                x: center.x + Math.cos(calculatedStartAngle) * radius,
+                y: center.y + Math.sin(calculatedStartAngle) * radius,
             };
             const end = {
                 x: center.x + Math.cos(to) * radius,


### PR DESCRIPTION
### Allow drawing arc instead of a full circle by defining `startDraw, endDraw`

#### example 

    const progress = Widget.CircularProgress({
        className: "desktop-cpu-circle",
        child: Widget.Label({
            className: "desktop-cpu-circle-icon",
            label: ""
        }),
        startDraw: 0.25,
        endDraw: 0.5,
    }).poll(1000, self => {
        Utils.execAsync(`/home/${Utils.USER}/.config/ags/scripts/cpu.sh`)
            .then(val => {
                progress.value = val / 100;
            }).catch(print);
    });

![2024-01-04-035744_hyprshot](https://github.com/Aylur/ags/assets/68832470/b5f74c1c-118d-4427-ac7c-de07a261296e)

#### if used without `startDraw, endDraw` it will draw a normal circle as it used to