### PR TITLE
Allow layer click-through

### DIFF
--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -2,6 +2,7 @@ import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk?version=3.0';
 import GLib from 'gi://GLib?version=2.0';
 import Gdk from 'gi://Gdk?version=3.0';
+import Cairo from 'gi://cairo?version=1.0';
 import Service, { kebabify, Props, BindableProps, Binding } from '../service.js';
 import { registerGObject } from '../gobject.js';
 import { interval } from '../utils.js';
@@ -83,6 +84,7 @@ export type BaseProps<Self extends Gtk.Widget, Props> = {
 } & BindableProps<Props & {
     class_name?: string
     class_names?: string[]
+    click_through?: boolean
     css?: string
     hpack?: Align
     vpack?: Align
@@ -217,6 +219,7 @@ export default function AgsWidget<
                     'cursor': ['string', 'rw'],
                     'is-destroyed': ['boolean', 'r'],
                     'attribute': ['jsobject', 'rw'],
+                    'click-through': ['boolean', 'rw'],
 
                     // FIXME: deprecated
                     'properties': ['jsobject', 'w'],
@@ -491,6 +494,17 @@ export default function AgsWidget<
                 [, x, y] = event.get_coords();
 
             return x > 0 && x < w && y > 0 && y < h;
+        }
+
+        get click_through() { return !!this._get('click-through'); }
+        set click_through(clickThrough: boolean) {
+            if (this.click_through === clickThrough)
+                return;
+
+            const value = clickThrough ? new Cairo.Region : null;
+            this.input_shape_combine_region(value);
+            this._set('click-through', value);
+            this.notify('click-through');
         }
     };
 }

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -1,6 +1,7 @@
 import AgsWidget, { type BaseProps } from './widget.js';
 import Gtk from 'gi://Gtk?version=3.0';
 import Gdk from 'gi://Gdk?version=3.0';
+import Cairo from 'gi://cairo?version=1.0';
 import { Binding } from '../service.js';
 import App from '../app.js';
 // @ts-expect-error missing types FIXME:
@@ -26,6 +27,7 @@ export type Exclusivity = 'normal' | 'ignore' | 'exclusive';
 
 export type WindowProps = BaseProps<AgsWindow, Gtk.Window.ConstructorProperties & {
     anchor?: Anchor[]
+    clickthrough?: boolean
     exclusivity?: Exclusivity
     focusable?: boolean
     layer?: Layer
@@ -43,6 +45,7 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
         AgsWidget.register(this, {
             properties: {
                 'anchor': ['jsobject', 'rw'],
+                'clickthrough': ['boolean', 'rw'],
                 'exclusive': ['boolean', 'rw'],
                 'exclusivity': ['string', 'rw'],
                 'focusable': ['boolean', 'rw'],
@@ -58,6 +61,7 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
     // so we can't rely on gobject constructor
     constructor({
         anchor = [],
+        clickthrough = false,
         exclusive,
         exclusivity = 'normal',
         focusable = false,
@@ -73,6 +77,7 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
         LayerShell.set_namespace(this, this.name);
 
         this._handleParamProp('anchor', anchor);
+        this._handleParamProp('clickthrough', clickthrough);
         this._handleParamProp('exclusive', exclusive);
         this._handleParamProp('exclusivity', exclusivity);
         this._handleParamProp('focusable', focusable);
@@ -274,5 +279,13 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
             this, LayerShell.KeyboardMode[focusable ? 'ON_DEMAND' : 'NONE']);
 
         this.notify('focusable');
+    }
+
+    set clickthrough(clickthrough: boolean) {
+        if(clickthrough) {
+            const region = new Cairo.Region();
+            this.input_shape_combine_region(region);
+        }
+        this.notify('clickthrough');
     }
 }

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -1,7 +1,6 @@
 import AgsWidget, { type BaseProps } from './widget.js';
 import Gtk from 'gi://Gtk?version=3.0';
 import Gdk from 'gi://Gdk?version=3.0';
-import Cairo from 'gi://cairo?version=1.0';
 import { Binding } from '../service.js';
 import App from '../app.js';
 // @ts-expect-error missing types FIXME:
@@ -27,7 +26,6 @@ export type Exclusivity = 'normal' | 'ignore' | 'exclusive';
 
 export type WindowProps = BaseProps<AgsWindow, Gtk.Window.ConstructorProperties & {
     anchor?: Anchor[]
-    clickthrough?: boolean
     exclusivity?: Exclusivity
     focusable?: boolean
     layer?: Layer
@@ -45,7 +43,6 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
         AgsWidget.register(this, {
             properties: {
                 'anchor': ['jsobject', 'rw'],
-                'clickthrough': ['boolean', 'rw'],
                 'exclusive': ['boolean', 'rw'],
                 'exclusivity': ['string', 'rw'],
                 'focusable': ['boolean', 'rw'],
@@ -63,7 +60,6 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
     // so we can't rely on gobject constructor
     constructor({
         anchor = [],
-        clickthrough = false,
         exclusive,
         exclusivity = 'normal',
         focusable = false,
@@ -79,7 +75,6 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
         LayerShell.set_namespace(this, this.name);
 
         this._handleParamProp('anchor', anchor);
-        this._handleParamProp('clickthrough', clickthrough);
         this._handleParamProp('exclusive', exclusive);
         this._handleParamProp('exclusivity', exclusivity);
         this._handleParamProp('focusable', focusable);
@@ -281,21 +276,5 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
             this, LayerShell.KeyboardMode[focusable ? 'ON_DEMAND' : 'NONE']);
 
         this.notify('focusable');
-    }
-
-    get clickthrough() {
-        return this._clickthrough;
-    }
-
-    set clickthrough(clickthrough: boolean) {
-        this._clickthrough = clickthrough;
-        if (clickthrough) {
-            const region = new Cairo.Region();
-            this.input_shape_combine_region(region);
-        }
-        else {
-            this.input_shape_combine_region(null);
-        }
-        this.notify('clickthrough');
     }
 }

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -288,8 +288,8 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
     }
 
     set clickthrough(clickthrough: boolean) {
+        this._clickthrough = clickthrough;
         if (clickthrough) {
-            this._clickthrough = clickthrough;
             const region = new Cairo.Region();
             this.input_shape_combine_region(region);
         }

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -54,8 +54,6 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
         });
     }
 
-    _clickthrough = false;
-
     // the window has to be set as a layer,
     // so we can't rely on gobject constructor
     constructor({

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -56,6 +56,8 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
         });
     }
 
+    _clickthrough = false;
+
     // the window has to be set as a layer,
     // so we can't rely on gobject constructor
     constructor({
@@ -280,9 +282,15 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
         this.notify('focusable');
     }
 
+    get clickthrough() {
+        return this._clickthrough;
+    }
+
     set clickthrough(clickthrough: boolean) {
-        if(clickthrough) 
+        if (clickthrough) {
+            this._clickthrough = clickthrough;
             this.input_shape_combine_region(null);
+        }
         this.notify('clickthrough');
     }
 }

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -1,7 +1,6 @@
 import AgsWidget, { type BaseProps } from './widget.js';
 import Gtk from 'gi://Gtk?version=3.0';
 import Gdk from 'gi://Gdk?version=3.0';
-import Cairo from 'gi://cairo?version=1.0';
 import { Binding } from '../service.js';
 import App from '../app.js';
 // @ts-expect-error missing types FIXME:
@@ -282,10 +281,8 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
     }
 
     set clickthrough(clickthrough: boolean) {
-        if(clickthrough) {
-            const region = new Cairo.Region();
-            this.input_shape_combine_region(region);
-        }
+        if(clickthrough) 
+            this.input_shape_combine_region(null);
         this.notify('clickthrough');
     }
 }

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -1,6 +1,7 @@
 import AgsWidget, { type BaseProps } from './widget.js';
 import Gtk from 'gi://Gtk?version=3.0';
 import Gdk from 'gi://Gdk?version=3.0';
+import Cairo from 'gi://cairo?version=1.0';
 import { Binding } from '../service.js';
 import App from '../app.js';
 // @ts-expect-error missing types FIXME:
@@ -289,6 +290,10 @@ export default class AgsWindow extends AgsWidget(Gtk.Window) {
     set clickthrough(clickthrough: boolean) {
         if (clickthrough) {
             this._clickthrough = clickthrough;
+            const region = new Cairo.Region();
+            this.input_shape_combine_region(region);
+        }
+        else {
             this.input_shape_combine_region(null);
         }
         this.notify('clickthrough');


### PR DESCRIPTION
## About this PR
Added "clickthrough" boolean property. Makes an AgsWindow not block mouse input for windows below if set to true
Example: 
- Screen corners in [Aylur's setup](https://github.com/Aylur/dotfiles) or my setup would benefit from not being clickable. I think this image explains it
![image](https://github.com/Aylur/ags/assets/97237370/697435f7-654e-4604-a78a-6debd5e4f66f)


## Does it need extra work?
Yes
I've only figured out how to make clickthrough work 
I haven't made it work the other way round and the getter func, and I'd really appreciate pointers on how to do these.

## Reference
- https://github.com/Kljunas2/activate-linux/pull/11
- https://docs.gtk.org/gtk3/method.Widget.input_shape_combine_region.html