### PR TITLE
feat: sway service

### DIFF
--- a/src/com.github.Aylur.ags.src.gresource.xml
+++ b/src/com.github.Aylur.ags.src.gresource.xml
@@ -50,6 +50,7 @@
     <file>service/bluetooth.js</file>
     <file>service/greetd.js</file>
     <file>service/hyprland.js</file>
+    <file>service/sway.js</file>
     <file>service/mpris.js</file>
     <file>service/network.js</file>
     <file>service/notifications.js</file>

--- a/src/service.ts
+++ b/src/service.ts
@@ -2,107 +2,108 @@ import GObject from 'gi://GObject';
 import { pspec, registerGObject, PspecFlag, PspecType } from './utils/gobject.js';
 
 export type Connectable = {
-    connect: (sig: string, callback: (...args: unknown[]) => unknown) => number
-    disconnect: (id: number) => void
+  connect: (sig: string, callback: (...args: unknown[]) => unknown) => number
+  disconnect: (id: number) => void
 }
 
 export type OnlyString<S extends string | unknown> = S extends string ? S : never;
 
 export type Props<T> = Omit<Pick<T, {
-    [K in keyof T]: T[K] extends (...args: any[]) => any ? never : OnlyString<K>
+  [K in keyof T]: T[K] extends (...args: any[]) => any ? never : OnlyString<K>
 }[keyof T]>, 'g_type_instance'>;
 
 export type BindableProps<T> = {
-    [K in keyof T]: Binding<any, any, NonNullable<T[K]>> | T[K];
+  [K in keyof T]: Binding<any, any, NonNullable<T[K]>> | T[K];
 }
 
 export class Binding<
-    Emitter extends GObject.Object,
-    Prop extends keyof Props<Emitter>,
-    Return = Emitter[Prop],
+  Emitter extends GObject.Object,
+  Prop extends keyof Props<Emitter>,
+  Return = Emitter[Prop],
 > {
-    emitter: Emitter;
-    prop: Prop;
-    transformFn = (v: any) => v; // see #262
-    constructor(emitter: Emitter, prop: Prop) {
-        this.emitter = emitter;
-        this.prop = prop;
-    }
+  emitter: Emitter;
+  prop: Prop;
+  transformFn = (v: any) => v; // see #262
+  constructor(emitter: Emitter, prop: Prop) {
+    this.emitter = emitter;
+    this.prop = prop;
+  }
 
-    /** alias for transform */
-    as<T>(fn: (v: Return) => T) { return this.transform(fn); }
+  /** alias for transform */
+  as<T>(fn: (v: Return) => T) { return this.transform(fn); }
 
-    transform<T>(fn: (v: Return) => T) {
-        const bind = new Binding<Emitter, Prop, T>(this.emitter, this.prop);
-        const prev = this.transformFn;
-        bind.transformFn = (v: Return) => fn(prev(v));
-        return bind;
-    }
+  transform<T>(fn: (v: Return) => T) {
+    const bind = new Binding<Emitter, Prop, T>(this.emitter, this.prop);
+    const prev = this.transformFn;
+    bind.transformFn = (v: Return) => fn(prev(v));
+    return bind;
+  }
 }
 
 interface Services {
-    applications: typeof import('./service/applications.js').default
-    audio: typeof import('./service/audio.js').default
-    battery: typeof import('./service/battery.js').default
-    bluetooth: typeof import('./service/bluetooth.js').default
-    hyprland: typeof import('./service/hyprland.js').default
-    mpris: typeof import('./service/mpris.js').default
-    network: typeof import('./service/network.js').default
-    notifications: typeof import('./service/notifications.js').default
-    powerprofiles: typeof import('./service/powerprofiles.js').default
-    systemtray: typeof import('./service/systemtray.js').default
-    greetd: typeof import('./service/greetd.js').default
+  applications: typeof import('./service/applications.js').default
+  audio: typeof import('./service/audio.js').default
+  battery: typeof import('./service/battery.js').default
+  bluetooth: typeof import('./service/bluetooth.js').default
+  hyprland: typeof import('./service/hyprland.js').default
+  mpris: typeof import('./service/mpris.js').default
+  network: typeof import('./service/network.js').default
+  notifications: typeof import('./service/notifications.js').default
+  powerprofiles: typeof import('./service/powerprofiles.js').default
+  systemtray: typeof import('./service/systemtray.js').default
+  greetd: typeof import('./service/greetd.js').default
+  sway: typeof import('./service/sway.js').default
 }
 
 export default class Service extends GObject.Object {
-    static {
-        GObject.registerClass({
-            GTypeName: 'AgsService',
-            Signals: { 'changed': {} },
-        }, this);
-    }
+  static {
+    GObject.registerClass({
+      GTypeName: 'AgsService',
+      Signals: { 'changed': {} },
+    }, this);
+  }
 
-    static async import<S extends keyof Services>(service: S): Promise<Services[S]> {
-        return (await import(`./service/${service}.js`)).default;
-    }
+  static async import<S extends keyof Services>(service: S): Promise<Services[S]> {
+    return (await import(`./service/${service}.js`)).default;
+  }
 
-    static pspec(name: string, type: PspecType = 'jsobject', handle: PspecFlag = 'r') {
-        return pspec(name, type, handle);
-    }
+  static pspec(name: string, type: PspecType = 'jsobject', handle: PspecFlag = 'r') {
+    return pspec(name, type, handle);
+  }
 
-    static register(
-        service: new (...args: any[]) => GObject.Object,
-        signals?: { [signal: string]: PspecType[] },
-        properties?: { [prop: string]: [type?: PspecType, handle?: PspecFlag] },
-    ) {
-        registerGObject(service, { signals, properties });
-    }
+  static register(
+    service: new (...args: any[]) => GObject.Object,
+    signals?: { [signal: string]: PspecType[] },
+    properties?: { [prop: string]: [type?: PspecType, handle?: PspecFlag] },
+  ) {
+    registerGObject(service, { signals, properties });
+  }
 
-    connect(signal = 'changed', callback: (_: this, ...args: any[]) => void): number {
-        return super.connect(signal, callback);
-    }
+  connect(signal = 'changed', callback: (_: this, ...args: any[]) => void): number {
+    return super.connect(signal, callback);
+  }
 
-    updateProperty(prop: string, value: unknown) {
-        if (this[prop as keyof typeof this] === value ||
-            JSON.stringify(this[prop as keyof typeof this]) === JSON.stringify(value))
-            return;
+  updateProperty(prop: string, value: unknown) {
+    if (this[prop as keyof typeof this] === value ||
+      JSON.stringify(this[prop as keyof typeof this]) === JSON.stringify(value))
+      return;
 
-        const privateProp = prop
-            .split('-')
-            .map((w, i) => i > 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w)
-            .join('');
+    const privateProp = prop
+      .split('-')
+      .map((w, i) => i > 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w)
+      .join('');
 
-        // @ts-expect-error
-        this[`_${privateProp}`] = value;
-        this.notify(prop);
-    }
+    // @ts-expect-error
+    this[`_${privateProp}`] = value;
+    this.notify(prop);
+  }
 
-    changed(property: string) {
-        this.notify(property);
-        this.emit('changed');
-    }
+  changed(property: string) {
+    this.notify(property);
+    this.emit('changed');
+  }
 
-    bind<Prop extends keyof Props<this>>(prop: Prop) {
-        return new Binding(this, prop);
-    }
+  bind<Prop extends keyof Props<this>>(prop: Prop) {
+    return new Binding(this, prop);
+  }
 }

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -4,8 +4,8 @@ import Service from '../service.js';
 
 const SIS = GLib.getenv('SWAYSOCK');
 
-const enum PAYLOAD_TYPE {
-    MESSAGE_RUM_COMMAND = 0,
+export const enum PAYLOAD_TYPE {
+    MESSAGE_RUN_COMMAND = 0,
     MESSAGE_GET_WORKSPACES = 1,
     MESSAGE_SUBSCRIBE = 2,
     MESSAGE_GET_OUTPUTS = 3,
@@ -125,7 +125,7 @@ export class SwayActiveID extends Service {
         });
     }
 
-    private _id = 1;
+    private _id = 0;
     private _name = '';
 
     get id() { return this._id; }
@@ -284,11 +284,9 @@ export class Sway extends Service {
         switch (workspaceEvent.change) {
             case 'init':
                 this._workspaces.set(workspace.name, workspace);
-                this.notify('workspaces');
                 break;
             case 'empty':
                 this._workspaces.delete(workspace.name);
-                this.notify('workspaces');
                 break;
             case 'focus':
                 this._active.workspace.update(workspace.id, workspace.name);
@@ -296,13 +294,11 @@ export class Sway extends Service {
 
                 this._workspaces.set(workspace.name, workspace);
                 this._workspaces.set(workspaceEvent.old.name, workspaceEvent.old);
-                this.notify('workspaces');
                 break;
             case 'rename':
                 if (this._active.workspace.id === workspace.id)
                     this._active.workspace.updateProperty('name', workspace.name);
                 this._workspaces.set(workspace.name, workspace);
-                this.notify('workspaces');
                 break;
             case 'reload':
                 break;
@@ -310,8 +306,8 @@ export class Sway extends Service {
             case 'urgent':
             default:
                 this._workspaces.set(workspace.name, workspace);
-                this.notify('workspaces');
         }
+        this.notify('workspaces');
     }
 
     private _handleWindowEvent(clientEvent: Client_Event) {
@@ -320,11 +316,9 @@ export class Sway extends Service {
         switch (clientEvent.change) {
             case 'new':
                 this._clients.set(id, client);
-                this.notify('clients');
                 break;
             case 'close':
                 this._clients.delete(id);
-                this.notify('clients');
                 break;
             case 'focus':
                 if (this._active.client.id === id)
@@ -344,7 +338,6 @@ export class Sway extends Service {
                 if (client.focused)
                     this._active.client.updateProperty('name', client.name);
                 this._clients.set(id, client);
-                this.notify('clients');
                 break;
             case 'fullscreen_mode':
             case 'move':
@@ -353,8 +346,8 @@ export class Sway extends Service {
             case 'mark':
             default:
                 this._clients.set(id, client);
-                this.notify('clients');
         }
+        this.notify('clients');
     }
 
     private _handleTreeMessage(node: Node) {
@@ -364,14 +357,11 @@ export class Sway extends Service {
                 this._clients.clear();
                 this._monitors.clear();
                 node.nodes.map(n => this._handleTreeMessage(n));
-                ['workspaces', 'clients', 'monitors'].forEach(t => {
-                    this.notify(t);
-                });
                 break;
             case 'output':
                 this._monitors.set(node.id, node);
                 if (node.active)
-                    this._active.monitor.updateProperty('name', node.name);
+                    this._active.monitor.update(node.id, node.name);
                 node.nodes.map(n => this._handleTreeMessage(n));
                 this.notify('monitors');
                 break;

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -339,6 +339,10 @@ export class Sway extends Service {
                 break;
             case 'fullscreen_mode':
             case 'move':
+                // Refresh tree since the event doesn't contain the relevant
+                // information to modify the workspaces property
+                this._send(PAYLOAD_TYPE.MESSAGE_GET_TREE, '');
+                break;
             case 'floating':
             case 'urgent':
             case 'mark':

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -1,0 +1,118 @@
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+import Service from './service.js';
+
+const SIS = GLib.getenv('SWAYSOCK');
+
+const enum PAYLOAD_TYPE {
+    MESSAGE_RUM_COMMAND = 0,
+    MESSAGE_GET_WORKSPACES = 1,
+    MESSAGE_SUBSCRIBE = 2,
+    MESSAGE_GET_OUTPUTS = 3,
+    MESSAGE_GET_TREE = 4,
+    MESSAGE_GET_MARKS = 5,
+    MESSAGE_GET_BAR_CONFIG = 6,
+    MESSAGE_GET_VERSION = 7,
+    MESSAGE_GET_BINDING_NODES = 8,
+    MESSAGE_GET_CONFIG = 9,
+    MESSAGE_SEND_TICK = 10,
+    MESSAGE_SYNC = 11,
+    MESSAGE_GET_BINDING_STATE = 12,
+    MESSAGE_GET_INPUTS = 100,
+    MESSAGE_GET_SEATS = 101,
+    EVENT_WORKSPACE = 0x8000000,
+    EVENT_MODE = 0x80000002,
+    EVENT_WINDOW =  0x80000003,
+    EVENT_BARCONFIG_UPDATE = 0x80000004,
+    EVENT_BINDING = 0x80000005,
+    EVENT_SHUTDOWN = 0x80000006,
+    EVENT_TICK =  0x80000007,
+    EVENT_BAR_STATE_UPDATE = 0x80000014,
+    EVENT_INPUT = 0x80000015,
+}
+
+class SwayService extends Service {
+    static {
+        Service.register(this);
+    }
+
+    private _decoder = new TextDecoder();
+    private _encoder = new TextEncoder();
+    private _output_stream: Gio.OutputStream;
+
+    constructor() {
+        if (!SIS)
+            console.error('Sway is not running');
+        super();
+        const socket = new Gio.SocketClient().connect(new Gio.UnixSocketAddress({
+            path: `${SIS}`,
+        }), null);
+
+        this._watchSocket(socket.get_input_stream());
+
+        this._output_stream = socket.get_output_stream();
+        this.send(PAYLOAD_TYPE.MESSAGE_SUBSCRIBE, JSON.stringify(['window', 'workspace']));
+    }
+
+    send(payload_type: PAYLOAD_TYPE, payload: string) {
+        const pb = this._encoder.encode(payload);
+        const type = new Uint32Array([payload_type]);
+        const pl = new Uint32Array([pb.length]);
+        const magic_string = this._encoder.encode('i3-ipc');
+        const data = new Uint8Array([
+            ...magic_string,
+            ...(new Uint8Array(pl.buffer)),
+            ...(new Uint8Array(type.buffer)),
+            ...pb]);
+        print(data);
+        this._output_stream.write_bytes(data, null);
+    }
+
+    private _watchSocket(stream: Gio.InputStream) {
+        stream.read_bytes_async(14, GLib.PRIORITY_DEFAULT, null, (_, result_header) => {
+            const data = stream.read_bytes_finish(result_header).get_data();
+            if (!data)
+                return;
+            const payload_length = new Uint32Array(data.slice(6, 10).buffer)[0];
+            const payload_type = new Uint32Array(data.slice(10, 14).buffer)[0];
+            stream.read_bytes_async(
+                payload_length,
+                GLib.PRIORITY_DEFAULT,
+                null,
+                (_, result_payload) => {
+                    const data = stream.read_bytes_finish(result_payload).get_data();
+                    if (!data)
+                        return;
+                    this._onEvent(payload_type, JSON.parse(this._decoder.decode(data)));
+                    this._watchSocket(stream);
+                });
+        });
+    }
+
+    private async _onEvent(event_type: PAYLOAD_TYPE, event: string) {
+        if (!event)
+            return;
+        try {
+            switch (event_type) {
+                case PAYLOAD_TYPE.EVENT_WORKSPACE:
+                    break;
+                case PAYLOAD_TYPE.EVENT_WINDOW:
+                    break;
+                default:
+                    break;
+            }
+        } catch (error) {
+            logError(error as Error);
+        }
+        this.emit('changed');
+    }
+}
+
+export default class Sway {
+    static _instance: SwayService;
+
+    static get instance() {
+        Service.ensureInstance(Sway, SwayService);
+        return Sway._instance;
+    }
+}

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -195,6 +195,21 @@ export class Sway extends Service {
     getWorkspace(name: string) { return this._workspaces.get(name); }
     getClient(id: number) { return this._clients.get(id); }
 
+    msg(payload: string) { this.send(PAYLOAD_TYPE.MESSAGE_RUN_COMMAND, payload); }
+
+    send(payloadType: PAYLOAD_TYPE, payload: string) {
+        const pb = this._encoder.encode(payload);
+        const type = new Uint32Array([payloadType]);
+        const pl = new Uint32Array([pb.length]);
+        const magic_string = this._encoder.encode('i3-ipc');
+        const data = new Uint8Array([
+            ...magic_string,
+            ...(new Uint8Array(pl.buffer)),
+            ...(new Uint8Array(type.buffer)),
+            ...pb]);
+        this._output_stream.write(data, null);
+    }
+
     constructor() {
         if (!SIS)
             console.error('Sway is not running');
@@ -218,19 +233,6 @@ export class Sway extends Service {
         this._active.connect('changed', () => this.emit('changed'));
         ['monitor', 'workspace', 'client'].forEach(active =>
             this._active.connect(`notify::${active}`, () => this.notify('active')));
-    }
-
-    send(payloadType: PAYLOAD_TYPE, payload: string) {
-        const pb = this._encoder.encode(payload);
-        const type = new Uint32Array([payloadType]);
-        const pl = new Uint32Array([pb.length]);
-        const magic_string = this._encoder.encode('i3-ipc');
-        const data = new Uint8Array([
-            ...magic_string,
-            ...(new Uint8Array(pl.buffer)),
-            ...(new Uint8Array(type.buffer)),
-            ...pb]);
-        this._output_stream.write(data, null);
     }
 
     private _watchSocket(stream: Gio.InputStream) {

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -179,7 +179,7 @@ export class Sway extends Service {
 
     private _decoder = new TextDecoder();
     private _encoder = new TextEncoder();
-    private _output_stream: Gio.OutputStream;
+    private _socket: Gio.SocketConnection;
 
     private _active: SwayActives;
     private _monitors: Map<number, object>;
@@ -207,13 +207,11 @@ export class Sway extends Service {
         this._workspaces = new Map();
         this._clients = new Map();
 
-        const socket = new Gio.SocketClient().connect(new Gio.UnixSocketAddress({
+        this._socket = new Gio.SocketClient().connect(new Gio.UnixSocketAddress({
             path: `${SIS}`,
         }), null);
 
-        this._watchSocket(socket.get_input_stream());
-
-        this._output_stream = socket.get_output_stream();
+        this._watchSocket(this._socket.get_input_stream());
         this._send(PAYLOAD_TYPE.MESSAGE_GET_TREE, '');
         this._send(PAYLOAD_TYPE.MESSAGE_SUBSCRIBE, JSON.stringify(['window', 'workspace']));
 
@@ -232,7 +230,7 @@ export class Sway extends Service {
             ...(new Uint8Array(pl.buffer)),
             ...(new Uint8Array(type.buffer)),
             ...pb]);
-        this._output_stream.write(data, null);
+        this._socket.get_output_stream().write(data, null);
     }
 
     private _watchSocket(stream: Gio.InputStream) {

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -337,13 +337,13 @@ export class Sway extends Service {
                     this._active.client.updateProperty('name', client.name);
                 this._clients.set(id, client);
                 break;
-            case 'fullscreen_mode':
+            case 'floating':
             case 'move':
-                // Refresh tree since the event doesn't contain the relevant
-                // information to modify the workspaces property
+                // Refresh tree since the event doesn't contain the relevant information
+                // to be able to modify `workspace.nodes` or `workspace.floating_nodes`
                 this._send(PAYLOAD_TYPE.MESSAGE_GET_TREE, '');
                 break;
-            case 'floating':
+            case 'fullscreen_mode':
             case 'urgent':
             case 'mark':
             default:

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -373,7 +373,7 @@ export class Sway extends Service {
                 // eslint-disable-next-line no-case-declarations
                 const hasFocusedChild: (n: Node) => boolean =
                     (n: Node) => n.nodes.some(c => c.focused || hasFocusedChild(c));
-                if (hasFocusedChild(node))
+                if (node.focused || hasFocusedChild(node))
                     this._active.workspace.update(node.id, node.name);
 
                 node.nodes.map(n => this._handleTreeMessage(n));

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -339,14 +339,15 @@ export class Sway extends Service {
                 if (client.focused)
                     this._active.client.updateProperty('name', client.name);
                 this._clients.set(id, client);
+                this.notify('clients');
                 break;
             case 'fullscreen_mode':
             case 'urgent':
             case 'mark':
             default:
                 this._clients.set(id, client);
+                this.notify('clients');
         }
-        this.notify('clients');
     }
 
     private _handleTreeMessage(node: Node) {

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -313,10 +313,13 @@ export class Sway extends Service {
         const id = client.id;
         switch (clientEvent.change) {
             case 'new':
-                this._clients.set(id, client);
-                break;
             case 'close':
-                this._clients.delete(id);
+            case 'floating':
+            case 'move':
+                // Refresh tree since client events don't contain the relevant information
+                // to be able to modify `workspace.nodes` or `workspace.floating_nodes`.
+                // There has to be a better way than this though :/
+                this._send(PAYLOAD_TYPE.MESSAGE_GET_TREE, '');
                 break;
             case 'focus':
                 if (this._active.client.id === id)
@@ -336,12 +339,6 @@ export class Sway extends Service {
                 if (client.focused)
                     this._active.client.updateProperty('name', client.name);
                 this._clients.set(id, client);
-                break;
-            case 'floating':
-            case 'move':
-                // Refresh tree since the event doesn't contain the relevant information
-                // to be able to modify `workspace.nodes` or `workspace.floating_nodes`
-                this._send(PAYLOAD_TYPE.MESSAGE_GET_TREE, '');
                 break;
             case 'fullscreen_mode':
             case 'urgent':

--- a/src/service/sway.ts
+++ b/src/service/sway.ts
@@ -20,7 +20,7 @@ const enum PAYLOAD_TYPE {
     MESSAGE_GET_BINDING_STATE = 12,
     MESSAGE_GET_INPUTS = 100,
     MESSAGE_GET_SEATS = 101,
-    EVENT_WORKSPACE = 0x8000000,
+    EVENT_WORKSPACE = 0x80000000,
     EVENT_MODE = 0x80000002,
     EVENT_WINDOW =  0x80000003,
     EVENT_BARCONFIG_UPDATE = 0x80000004,
@@ -29,6 +29,81 @@ const enum PAYLOAD_TYPE {
     EVENT_TICK =  0x80000007,
     EVENT_BAR_STATE_UPDATE = 0x80000014,
     EVENT_INPUT = 0x80000015,
+}
+
+interface Client_Event {
+    change: string,
+    container: Node,
+}
+
+interface Workspace_Event {
+    change: string,
+    current: Node,
+    old: Node,
+}
+
+interface Geometry {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+}
+
+//NOTE: not all properties are listed here
+interface Node {
+    id: number,
+    name: string,
+    type: string,
+    border: string
+    current_border_width: number
+    layout:  string
+    orientation: string
+    percent: number
+    rect: Geometry
+    window_rect: Geometry
+    deco_rect: Geometry
+    geometry: Geometry
+    urgent: boolean
+    sticky: boolean
+    marks: [string]
+    focused: boolean
+    focus: [number]
+    nodes: [Node]
+    floating_nodes: [Node]
+    representation: string
+    fullscreen_mode: number
+    app_id: string
+    pid: number
+    visible: boolean
+    shell: string
+    output: string,
+    inhibit_idle: boolean
+    idle_inhibitors: {
+        application: string,
+        user: string,
+    }
+    window: number
+    window_properties: {
+        title: string,
+        class: string,
+        instance: string,
+        window_role: string,
+        window_type: string,
+        transient_for: string,
+    }
+}
+
+interface Active {
+    client: {
+        id: number
+        title: string
+        class: string
+    }
+    monitor: string
+    workspace: {
+        id: number
+        name: string
+    }
 }
 
 class SwayService extends Service {
@@ -40,10 +115,38 @@ class SwayService extends Service {
     private _encoder = new TextEncoder();
     private _output_stream: Gio.OutputStream;
 
+    private _active: Active;
+    private _monitors: Map<number, object>;
+    private _workspaces: Map<number, object>;
+    private _clients: Map<number, Node>;
+
+    get active() { return this._active; }
+    get monitors() { return this._monitors; }
+    get workspaces() { return this._workspaces; }
+    get clients() { return this._clients; }
+
     constructor() {
         if (!SIS)
             console.error('Sway is not running');
         super();
+
+        this._active = {
+            client: {
+                id: 0,
+                title: '',
+                class: '',
+            },
+            monitor: '',
+            workspace: {
+                id: 0,
+                name: '',
+            },
+        };
+
+        this._monitors = new Map();
+        this._workspaces = new Map();
+        this._clients = new Map();
+
         const socket = new Gio.SocketClient().connect(new Gio.UnixSocketAddress({
             path: `${SIS}`,
         }), null);
@@ -51,6 +154,7 @@ class SwayService extends Service {
         this._watchSocket(socket.get_input_stream());
 
         this._output_stream = socket.get_output_stream();
+        //TODO init everything by mybe using get_tree
         this.send(PAYLOAD_TYPE.MESSAGE_SUBSCRIBE, JSON.stringify(['window', 'workspace']));
     }
 
@@ -64,7 +168,6 @@ class SwayService extends Service {
             ...(new Uint8Array(pl.buffer)),
             ...(new Uint8Array(type.buffer)),
             ...pb]);
-        print(data);
         this._output_stream.write_bytes(data, null);
     }
 
@@ -89,14 +192,16 @@ class SwayService extends Service {
         });
     }
 
-    private async _onEvent(event_type: PAYLOAD_TYPE, event: string) {
+    private async _onEvent(event_type: PAYLOAD_TYPE, event: object) {
         if (!event)
             return;
         try {
             switch (event_type) {
                 case PAYLOAD_TYPE.EVENT_WORKSPACE:
+                    this._handle_workspace_event(event as Workspace_Event);
                     break;
                 case PAYLOAD_TYPE.EVENT_WINDOW:
+                    this._handle_window_event(event as Client_Event);
                     break;
                 default:
                     break;
@@ -105,6 +210,74 @@ class SwayService extends Service {
             logError(error as Error);
         }
         this.emit('changed');
+    }
+
+    private _handle_workspace_event(workspace_event: Workspace_Event) {
+        const workspace = workspace_event.current;
+        switch (workspace_event.change) {
+            case 'init':
+                this._workspaces.set(workspace.id, workspace);
+                break;
+            case 'empty':
+                this._workspaces.delete(workspace.id);
+                break;
+            case 'focus':
+                this._active.workspace.id = workspace.id;
+                this._active.workspace.name = workspace.name;
+                this._active.monitor = workspace.output;
+                this._workspaces.set(workspace.id, workspace);
+                this._workspaces.set(workspace_event.old.id, workspace_event.old);
+                break;
+            case 'rename':
+                if (this._active.workspace.id === workspace.id)
+                    this._active.workspace.name = workspace.name;
+                this._workspaces.set(workspace.id, workspace);
+                break;
+            case 'reload':
+                break;
+            case 'move':
+            case 'urgent':
+            default:
+                this._workspaces.set(workspace.id, workspace);
+        }
+    }
+
+    private _handle_window_event(client_event: Client_Event) {
+        const client = client_event.container;
+        const id = client.id;
+        switch (client_event.change) {
+            case 'new':
+                this._clients.set(id, client);
+                break;
+            case 'close':
+                this._clients.delete(id);
+                break;
+            case 'focus':
+                if (this._active.client.id === id)
+                    return;
+                // eslint-disable-next-line no-case-declarations
+                const current_active = this._clients.get(this._active.client.id);
+                if (current_active)
+                    current_active.focused = false;
+                this._active.client.id = id;
+                this._active.client.title = client.name;
+                this._active.client.class = client.shell === 'xwayland'
+                    ? client.window_properties?.class || ''
+                    : client.app_id;
+                break;
+            case 'title':
+                if (client.focused)
+                    this._active.client.title = client.name;
+                this._clients.set(id, client);
+                break;
+            case 'fullscreen_mode':
+            case 'move':
+            case 'floating':
+            case 'urgent':
+            case 'mark':
+            default:
+                this._clients.set(id, client);
+        }
     }
 }
 
@@ -115,4 +288,9 @@ export default class Sway {
         Service.ensureInstance(Sway, SwayService);
         return Sway._instance;
     }
+
+    static get monitors() { return Array.from(Sway.instance.monitors.values()); }
+    static get workspaces() { return Array.from(Sway.instance.workspaces.values()); }
+    static get clients() { return Array.from(Sway.instance.clients.values()); }
+    static get active() { return Sway.instance.active; }
 }


### PR DESCRIPTION
Adds a sway service with usage similar to the hyprland service

- [x] initial sway ipc @kotontrion 
- [x] update service implementation patterns
- [x] Sway.msg utility function
- [x] add example widget
- [x] ~~consider unifying active types~~
- [x] ~~examine `getWorkspace(id)` usage, sway uses `workspace.name` (ids are random), hyprland uses `workspace.id` (ids are fixed)~~
- [x] ~~explore unified workspace service~~
- [x] fix ipc socket writer closing on its own
- [ ] cleanup how workspace.nodes are maintained

## Example

```js
import Widget from "resource:///com/github/Aylur/ags/widget.js";
import Sway from "resource:///com/github/Aylur/ags/service/sway.js";

const Workspaces = () => {
  return Widget.Box({
    children: Array.from({ length: 20 }, (_, i) => {
      i += 1;
      return Widget.Button({
        setup: (btn) => {
          btn.hook(Sway, (btn) => {
            const ws = Sway.getWorkspace(`${i}`);
            btn.visible = ws !== undefined;
            btn.toggleClassName("occupied", ws?.nodes.length + ws?.floating_nodes.length > 0);
          }, 'notify::workspaces');

          btn.hook(Sway.active.workspace, (btn) => {
            btn.toggleClassName("active", Sway.active.workspace.name == i);
          });
        },
        on_clicked: () => Sway.msg(`workspace ${i}`),
        child: Widget.Label({
          label: `${i}`,
          class_name: "indicator",
          vpack: "center",
        }),
      })
    }),
  });
};

export default () =>
  Widget.EventBox({
    class_name: "workspaces panel-button",
    child: Widget.Box({
      child: Widget.EventBox({
        on_scroll_up: () => Sway.msg("workspace next"),
        on_scroll_down: () => Sway.msg("workspace prev"),
        class_name: "eventbox",
        child: Workspaces(),
      }),
    }),
  });
```