### PR TITLE
Multiple changes for Hyprland.ts

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -320,7 +320,7 @@ export class Hyprland extends Service {
             if (error instanceof Error)
                 console.error(error.message);
         }
-        
+
         this.emit('event', e, params);
         this.emit('changed');
     }

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -290,7 +290,6 @@ export class Hyprland extends Service {
                     this._active.client.updateProperty('title', '');
                     this._active.client.updateProperty('address', '');
                     await this._syncWorkspaces();
-                    this._clients.delete('0x' + argv[0]);
                     await this._syncClients();
                     this.emit('client-removed', '0x' + argv[0]);
                     this.notify('clients');

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -225,8 +225,6 @@ export class Hyprland extends Service {
         const [e, params] = event.split('>>');
         const argv = params.split(',');
 
-        this.emit('event', e, params);
-
         try {
             switch (e) {
                 case 'workspace':
@@ -323,7 +321,8 @@ export class Hyprland extends Service {
             if (error instanceof Error)
                 console.error(error.message);
         }
-
+        
+        this.emit('event', e, params);
         this.emit('changed');
     }
 }

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -293,6 +293,7 @@ export class Hyprland extends Service {
                     this._active.client.updateProperty('address', '');
                     await this._syncWorkspaces();
                     this._clients.delete('0x' + argv[0]);
+                    await this._syncClients();
                     this.emit('client-removed', '0x' + argv[0]);
                     this.notify('clients');
                     break;


### PR DESCRIPTION
-added _syncClients call to moveworkspaces case so that clients show their correct position and monitor after a workspace is moved between monitors

-added _syncClients call to closewindow case so that client x,y coordinate and size values are updated when they fill the newly available screen space

-moved 'event' emit command to after the switch statement so that the 'Hyprland' service clients/workspaces/monitors are up-to-date by the time the user receives the signal