### PR TITLE
fix reintroduced race(?) condition

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -267,7 +267,8 @@ export class Hyprland extends Service {
                 case 'moveworkspace':
                     await this._syncClients(false);
                     await this._syncWorkspaces(false);
-                    await this._syncMonitors(false); // has to be called last because of active signals
+                    // has to be called last because of active signals in syncMonitors
+                    await this._syncMonitors(false);
                     ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
                     break;
 

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -267,7 +267,7 @@ export class Hyprland extends Service {
                 case 'moveworkspace':
                     await this._syncClients(false);
                     await this._syncWorkspaces(false);
-                    await this._syncMonitors(false);
+                    await this._syncMonitors(false); // has to be called last because of active signals
                     ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
                     break;
 

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -177,10 +177,10 @@ export class Hyprland extends Service {
                 if (monitor.focused) {
                     this._active.monitor.update(monitor.id, monitor.name);
                     this._active.workspace.update(activeWorkspace.id, activeWorkspace.name);
-                    this._active.monitor.emit('changed');
-                    this._active.workspace.emit('changed');
                 }
             });
+            this._active.monitor.emit('changed');
+            this._active.workspace.emit('changed');
             if (notify)
                 this.notify('monitors');
         } catch (error) {


### PR DESCRIPTION
Calling the emit functions within the foreach loop reintroduced the error in exactly the same place it was before, albeit thanks to all the work done in commits #205fc55 and #106b4f3 the fix is simply a matter of placement. This code (like previously) works fine only when focusing the monitor with the greatest id, i.e., last in the array, otherwise the emit is too early and sends the 'changed' signal with only a partially constructed monitors array. Moving the emits to after the foreach should rectify this, however I'm not currently in a position to test it myself.