### PR TITLE
fix default notification timeout not applied

### DIFF
--- a/src/service/notifications.ts
+++ b/src/service/notifications.ts
@@ -348,7 +348,7 @@ export class Notifications extends Service {
         const id = replacesId || this._idCount++;
         const n = new Notification(appName, id, appIcon, summary, body, acts, hints, !this.dnd);
 
-        if (App.config.notificationForceTimeout) {
+        if (App.config.notificationForceTimeout || expiration === -1) {
             n.timeout = App.config.notificationPopupTimeout;
             timeout(App.config.notificationPopupTimeout, () => this.DismissNotification(id));
         } else {


### PR DESCRIPTION
 After changes in https://github.com/Aylur/ags/commit/478008255575273159411afa0bebebdc6ab3160c, `notificationPopupTimeout` is no longer applied to notifications with `expiration == -1`, which "expiration time is dependent on the notification server's settings", according to [the spec](https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html).