### PR TITLE
fix/mpris: update identity on _updateState()

### DIFF
--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -172,6 +172,7 @@ export class MprisPlayer extends Service {
         this.updateProperty('track-title', trackTitle);
         this.updateProperty('track-cover-url', trackCoverUrl);
         this.updateProperty('length', length);
+        this.updateProperty('identity', this._mprisProxy.Identity);
         this._cacheCoverArt();
         this.emit('changed');
     }


### PR DESCRIPTION
This fixes a problem I had, since I'm using playerctld. The identity of the player wouldn't get updated when playerctld shifted between players, making it a lot harder to fetch the right application icon.