### PR TITLE
Improve post_install.sh

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -67,3 +67,7 @@ done
 for file in $SRC/src/widgets/*.ts; do
 	resource "widgets/$(basename -s .ts $file)" >>$dts
 done
+
+for file in $SRC/src/utils/*.ts; do
+	resource "utils/$(basename -s .ts $file)" >>$dts
+done

--- a/post_install.sh
+++ b/post_install.sh
@@ -20,7 +20,7 @@ TYPES="$PKGDATA_DIR/types"
 
 mkdir -p $TYPES
 
-tsc $SCR -d --declarationDir $TYPES --emitDeclarationOnly
+tsc -p $SRC/tsconfig.json -d --declarationDir $TYPES --emitDeclarationOnly
 
 function fixPaths {
 	sed -i 's/node_modules/types/g' $1


### PR DESCRIPTION
`utils/` subfolder doesn't get types, as mentioned here: #285
Also found a typo while reading through the file, which made it so `tsc` wasn't given a source directory. Probably wouldn't have caused a problem, but I tried a fix anyway.