### PR TITLE
Remove extra callback execution on widgets' `.poll()` method call

### DIFF
--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -215,7 +215,6 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         timeout: number,
         callback: (self: this) => void,
     ): this {
-        callback(this);
         interval(timeout, () => callback(this), this);
         return this;
     }


### PR DESCRIPTION
`utils.timeout.interval()` which is used by `.poll()` itself executes the first callback before setting up the timer, so there's no need for `.poll()` to do it, as this leads to callback being executed twice.