### PR TITLE
improve package overriding inside home-manager

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -25,6 +25,15 @@ in {
       '';
     };
 
+    finalPackage = mkOption {
+      type = types.package;
+      readOnly = true;
+      visible = false;
+      description = ''
+        Resulting ags package.
+      '';
+    };
+
     configDir = mkOption {
       type = with types; nullOr path;
       default = null;
@@ -55,6 +64,7 @@ in {
         buildTypes = true;
       };
     in {
+      programs.ags.finalPackage = pkg;
       home.packages = [pkg];
       home.file.".local/${path}".source = "${pkg}/${path}";
     }))


### PR DESCRIPTION
The final overriden package is now accessible by the user via `config.ags.package`. This is useful if the user wants to re-use the package somewhere else.

`extraPackages` will also now add the packages into `ags`'s environment, instead of just modifying `buildInputs` (which effectively does nothing).