### PR TITLE
Remove the `type` parameter from `Utils.monitorFile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - hyprland service: workspace and monitor signal emit number
 - hyprland service: deprecate sendMessage, introduce message and messageAsync
 - Variable: value check on setter, force on setValue
+- `Utils.monitorFile()` no longer takes the `type` (`file` or `directory`) parameter. It will monitor each accordingly without specifying it.
 
 # 1.7.5
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -73,14 +73,19 @@ const fileMonitors: Map<Gio.FileMonitor, boolean> = new Map;
 export function monitorFile(
     path: string,
     callback?: (file: Gio.File, event: Gio.FileMonitorEvent) => void,
-    type: 'file' | 'directory' = 'file',
     flags = Gio.FileMonitorFlags.NONE,
 ) {
+    // FIXME: remove the checking in the next release
+    if (flags === 'file' || flags === 'directory') {
+        throw Error(
+            `${flags}` + ' passed as a parameter in `monitorFile`. ' +
+            'Specifying the type is no longer required.'
+        );
+    }
+
     try {
         const file = Gio.File.new_for_path(path);
-        const mon = type === 'directory'
-            ? file.monitor_directory(flags, null)
-            : file.monitor_file(flags, null);
+        const mon = file.monitor(flags, null);
 
         if (callback)
             mon.connect('changed', (_, file, _f, event) => callback(file, event));

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -76,6 +76,7 @@ export function monitorFile(
     flags = Gio.FileMonitorFlags.NONE,
 ) {
     // FIXME: remove the checking in the next release
+    // @ts-expect-error
     if (flags === 'file' || flags === 'directory') {
         throw Error(
             `${flags}` + ' passed as a parameter in `monitorFile`. ' +

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -79,7 +79,7 @@ export function monitorFile(
     if (flags === 'file' || flags === 'directory') {
         throw Error(
             `${flags}` + ' passed as a parameter in `monitorFile`. ' +
-            'Specifying the type is no longer required.'
+            'Specifying the type is no longer required.',
         );
     }
 


### PR DESCRIPTION
`file.monitor()` handles both files and directories so there's no need to specify the type explicitly.
