### PR TITLE
ci: build agsWithTypes for the binary cache

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -21,4 +21,6 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: Build ags
-      run: nix build --print-build-logs
+      run: |
+        nix build --print-build-logs
+        nix build --print-build-logs .#agsWithTypes


### PR DESCRIPTION
`agsWithTypes` produces a different derivation, so it should be built too so that it can be cached.