### PR TITLE
Improve reproducibility of the nix workflows

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -11,9 +11,7 @@ jobs:
       with:
         submodules: recursive
 
-    - uses: DeterminateSystems/nix-installer-action@main
-      with:
-        logger: pretty
+    - uses: cachix/install-nix-action@v25
     - uses: DeterminateSystems/magic-nix-cache-action@main
     - uses: cachix/cachix-action@v12
       with:

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   src = buildNpmPackage {
     name = pname;
-    src = ../.;
+    src = lib.cleanSource ../.;
 
     dontBuild = true;
 


### PR DESCRIPTION
The `nix-installer-action` from `DeterminateSystems` was causing weird reproducibility issues, where the derivation hash produced in the CI differs from the one produced by my local environment. 

I'm not sure why it's happening, but simply switching to the `install-nix-action` provided by Cachix fixes this issue. You can test this by building locally, then comparing the produced nix store path with the one in the CI logs.

Also added a [lib.cleanSource](https://noogle.dev/f/lib/cleanSource) pass to the source tree, to further improve reproducibility.
