### PR TITLE
fix: TypeScript errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# git
+
+## Fixes
+
+- compiles with typescript >= 5.0.4
+
 # 1.8.0
 
 ## Features

--- a/src/utils/binding.ts
+++ b/src/utils/binding.ts
@@ -32,12 +32,12 @@ export function derive<V,
 type B<T> = Binding<Variable<T>, any, T>
 
 // eslint-disable-next-line max-len
-export function watch<T>(init: T, objs: Array<Connectable | [Connectable, signal?: string]>, callback: () => T): B<T>
+export function watch<T>(init: T, objs: Array<Connectable | [obj: Connectable, signal?: string]>, callback: () => T): B<T>
 export function watch<T>(init: T, obj: Connectable, signal: string, callback: () => T): B<T>
 export function watch<T>(init: T, obj: Connectable, callback: () => T): B<T>
 export function watch<T>(
     init: T,
-    objs: Connectable | Array<Connectable | [Connectable, signal?: string]>,
+    objs: Connectable | Array<Connectable | [obj: Connectable, signal?: string]>,
     sigOrFn: string | (() => T),
     callback?: () => T,
 ) {

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -59,7 +59,7 @@ export class Variable<T> extends GObject.Object {
         if (this._interval)
             return console.error(Error(`${this} is already polling`));
 
-        const [time, cmd, transform = out => out as T] = this._poll;
+        const [time, cmd, transform = (out: string) => out as T] = this._poll;
         if (Array.isArray(cmd) || typeof cmd === 'string') {
             this._interval = interval(time, () => execAsync(cmd)
                 .then(out => this.value = transform(out, this))

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -239,17 +239,14 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         keyOrCallback: Key | Fn,
         callback?: Fn,
     ): this {
-        const mods = callback ? modsOrKey as Mod : [] as any[];
+        const mods = callback ? modsOrKey as Mod : [] as unknown as Mod;
         const key = callback ? keyOrCallback as Key : modsOrKey as Key;
         const fn = callback ? callback : keyOrCallback as Fn;
 
         this.connect('key-press-event', (_, event: Gdk.Event) => {
             const k = event.get_keyval()[1];
             const m = event.get_state()[1];
-            const ms = mods.reduce(
-                (ms, m) => ms | Gdk.ModifierType[`${m}_MASK` as keyof typeof Gdk.ModifierType],
-                0,
-            );
+            const ms = mods.reduce((ms, m) => ms | Gdk.ModifierType[`${m}_MASK`], 0);
 
             if (mods.length > 0 && k === Gdk[`KEY_${key}`] && m === ms)
                 return fn(this, event);

--- a/src/widgets/widget.ts
+++ b/src/widgets/widget.ts
@@ -239,14 +239,18 @@ export class AgsWidget<Attr> extends Gtk.Widget implements Widget<Attr> {
         keyOrCallback: Key | Fn,
         callback?: Fn,
     ): this {
-        const mods = callback ? modsOrKey as Mod : [];
+        const mods = callback ? modsOrKey as Mod : [] as any[];
         const key = callback ? keyOrCallback as Key : modsOrKey as Key;
         const fn = callback ? callback : keyOrCallback as Fn;
 
         this.connect('key-press-event', (_, event: Gdk.Event) => {
             const k = event.get_keyval()[1];
             const m = event.get_state()[1];
-            const ms = mods.reduce((ms, m) => ms | Gdk.ModifierType[`${m}_MASK`], 0);
+            const ms = mods.reduce(
+                (ms, m) => ms | Gdk.ModifierType[`${m}_MASK` as keyof typeof Gdk.ModifierType],
+                0,
+            );
+
             if (mods.length > 0 && k === Gdk[`KEY_${key}`] && m === ms)
                 return fn(this, event);
 

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -126,14 +126,19 @@ export class Window<Child extends Gtk.Widget, Attr> extends Gtk.Window {
     set child(child: Child) { super.child = child; }
 
     get gdkmonitor(): Gdk.Monitor | null { return this._get('gdkmonitor') || null; }
-    set gdkmonitor(monitor: Gdk.Monitor) {
+    set gdkmonitor(monitor: Gdk.Monitor | null) {
         this._set('gdkmonitor', monitor);
         LayerShell.set_monitor(this, monitor);
         this.notify('gdkmonitor');
     }
 
-    get monitor(): Gdk.Monitor { return this._get('monitor'); }
-    set monitor(monitor: number) {
+    get monitor(): Gdk.Monitor | number { return this._get('monitor'); }
+    set monitor(monitor: Gdk.Monitor | number) {
+        if (monitor instanceof Gdk.Monitor) {
+            this.gdkmonitor = monitor;
+            return;
+        }
+
         if (monitor < 0)
             return;
 

--- a/src/widgets/window.ts
+++ b/src/widgets/window.ts
@@ -132,13 +132,8 @@ export class Window<Child extends Gtk.Widget, Attr> extends Gtk.Window {
         this.notify('gdkmonitor');
     }
 
-    get monitor(): Gdk.Monitor | number { return this._get('monitor'); }
-    set monitor(monitor: Gdk.Monitor | number) {
-        if (monitor instanceof Gdk.Monitor) {
-            this.gdkmonitor = monitor;
-            return;
-        }
-
+    get monitor(): number { return this._get('monitor'); }
+    set monitor(monitor: number) {
         if (monitor < 0)
             return;
 


### PR DESCRIPTION
Fixes #312 (typescript errors)

~~Not sure why only in Fedora (typescript version is 5.1.3), but I managed to fix these errors.~~
I know why this happens, it's because of the typescript version, alternative solution in this other PR #333


Apparently, all tuple members must have names (or no names)

```diff
../src/utils/binding.ts(35,62): error TS5084: Tuple members must all have names or all not have names.
../src/utils/binding.ts(40,46): error TS5084: Tuple members must all have names or all not have names.

- [Connectable, signal?: string]
+ [obj: Connectable, signal?: string]
```

It assumes that empty array [] to be of type never[], and for some reason it says "reduce" isn't callable? This can be fixed by using `new Array` instead of [] (but the linter complains about it) or just define the type to be any[].

```diff
../src/widgets/widget.ts(249,29): error TS2349: This expression is not callable.
  Each member of the union type '{ (callbackfn: (previousValue: "SHIFT" | "LOCK" | "CONTROL" | "MOD1" | "MOD2" | "MOD3" | "MOD4" | "MOD5" | "BUTTON1" | "BUTTON2" | "BUTTON3" | "BUTTON4" | "BUTTON5" | "MODIFIER_RESERVED_13" | "MODIFIER_RESERVED_14" | ... 16 more ... | "MODIFIER", currentValue: "SHIFT" | ... 30 more ... | "MODIFIER", currentIndex: nu...' has signatures, but none of those signatures are compatible with each other.
../src/widgets/widget.ts(249,37): error TS7006: Parameter 'ms' implicitly has an 'any' type.
../src/widgets/widget.ts(249,41): error TS7006: Parameter 'm' implicitly has an 'any' type.

- const mods = callback ? modsOrKey as Mod : [];
+ const mods = callback ? modsOrKey as Mod : [] as any[];
```

This one complains that the index \`${m}_MASK\` isn't a number...

```diff
../src/widgets/widget.ts(249,69): error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.

- const ms = mods.reduce((ms, m) => ms | Gdk.ModifierType[`${m}_MASK`], 0);
+ const ms = mods.reduce(
+     (ms, m) => ms | Gdk.ModifierType[`${m}_MASK` as keyof typeof Gdk.ModifierType],
+     0,
+ );
```