### PR TITLE
Update TypeScript version and add npm scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "GPL",
             "dependencies": {
-                "typescript": "^5.1.0"
+                "typescript": "^5.3.3"
             },
             "devDependencies": {
                 "@girs/cairo-1.0": "^1.0.0-3.2.7",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
         "eslint": "^8.42.0"
     },
     "scripts": {
+        "meson-setup": "meson setup --wipe build",
+        "meson-install": "meson install -C build",
         "test": "eslint ."
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Aylur",
     "license": "GPL",
     "dependencies": {
-        "typescript": "^5.1.0"
+        "typescript": "^5.3.3"
     },
     "devDependencies": {
         "@girs/cairo-1.0": "^1.0.0-3.2.7",


### PR DESCRIPTION
Fixes #312

This updates the typescript version in the package.json to the latest (5.3.3) and adds npm scripts to run meson commands.

By default, meson uses the typescript installed in the user's system, but dnf installs a really old version (5.1.3) and it doesn't currently work (unless these changes are made #332).

Running meson through a npm script forces it to use the local typescript installed by npm, which is more reliable because we don't need to depend on the user's package manager to install the right version, just let npm install it.

Build and installation would be as simple as:

```
npm install
npm run meson-setup
npm run meson-install
```

Technically we don't need to run meson install through npm, just meson setup, but this is for the sake of consistency.

Here's the output of meson setup, showing that it uses the typescript version installed by npm.

![image](https://github.com/Aylur/ags/assets/121690516/26bb5788-81bd-46c2-99cb-d8caefab483e)
