### PR TITLE
Fix "dispose" signal emission for Variable

### DIFF
--- a/src/variable.ts
+++ b/src/variable.ts
@@ -23,7 +23,7 @@ export class Variable<T> extends GObject.Object {
     static {
         Service.register(this, {
             'changed': [],
-            'disposed': [],
+            'dispose': [],
         }, {
             'value': ['jsobject', 'rw'],
             'is-listening': ['boolean', 'r'],


### PR DESCRIPTION
The actual behavior is when calling "myVariable.dispose()" there is the following error: `Error: No signal 'dispose' on object 'Ags_Variable'`

there is a mismatch between the "dispose" signal emission (emitted as "dispose") and its declaration (declared as "disposed")

This MR fix the signal declaration as "dispose" to be aligned with all other widgets.

