### PR TITLE
[BUG]: example applauncher ignores search query when pressing enter

### DIFF
--- a/example/applauncher/applauncher.js
+++ b/example/applauncher/applauncher.js
@@ -49,7 +49,9 @@ const Applauncher = ({ width = 500, height = 500, spacing = 12 }) => {
 
         // to launch the first item on Enter
         on_accept: () => {
-            if (applications[0]) {
+            // make sure we only consider visible (searched for) applications
+			const results = applications.filter((item) => item.visible);
+            if (results[0]) {
                 App.toggleWindow(WINDOW_NAME)
                 applications[0].attribute.app.launch()
             }

--- a/example/applauncher/applauncher.js
+++ b/example/applauncher/applauncher.js
@@ -50,7 +50,7 @@ const Applauncher = ({ width = 500, height = 500, spacing = 12 }) => {
         // to launch the first item on Enter
         on_accept: () => {
             // make sure we only consider visible (searched for) applications
-			const results = applications.filter((item) => item.visible);
+	    const results = applications.filter((item) => item.visible);
             if (results[0]) {
                 App.toggleWindow(WINDOW_NAME)
                 applications[0].attribute.app.launch()


### PR DESCRIPTION
I found an issue with the example applauncher. Whenever you search for an application, for example "spotify", and you press enter, it will not launch spotify (in my case it launched my terminal). It turns out it the code was just launching the first application, ignoring if it is visible or not.