### PR TITLE
feat(Network): add access point frequency

### DIFF
--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -111,7 +111,7 @@ export class Wifi extends Service {
         // TODO make signals actually signal when they should
         this._apBind = this._ap.connect('notify::strength', () => {
             this.emit('changed');
-            ['enabled', 'internet', 'strength', 'access-points', 'ssid', 'state', 'icon-name']
+            ['enabled', 'internet', 'strength', 'frequency', 'access-points', 'ssid', 'state', 'icon-name']
                 .map(prop => this.notify(prop));
         });
     }

--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -63,6 +63,7 @@ export class Wifi extends Service {
             'enabled': ['boolean', 'rw'],
             'internet': ['boolean'],
             'strength': ['int'],
+            'frequency': ['int'],
             'access-points': ['jsobject'],
             'ssid': ['string'],
             'state': ['string'],
@@ -125,6 +126,7 @@ export class Wifi extends Service {
                 : 'Unknown',
             active: ap === this._ap,
             strength: ap.strength,
+            frequency: ap.frequency,
             iconName: _STRENGTH_ICONS.find(({ value }) => value <= ap.strength)?.icon,
         }));
     }
@@ -133,6 +135,7 @@ export class Wifi extends Service {
     set enabled(v) { this._client.wireless_enabled = v; }
 
     get strength() { return this._ap?.strength || -1; }
+    get frequency() { return this._ap?.frequency || -1; }
     get internet() { return _INTERNET(this._device); }
     get ssid() {
         if (!this._ap)


### PR DESCRIPTION
I'm often connected to a wifi which uses the same ssid for 2.4ghz and 5ghz, even though I set my network to prefer the 5ghz network, it sometimes chooses 2.4ghz.

I'd like to see immediately which frequency I'm on to deal with the low signal strength by either choosing a different desk or manually reconnecting to the 5ghz network.

The frequency is returned as an integer, 5ghz for example will return 5580.

I have thought about abstracting it further into an enum/string/union, but this should be more future proof and easy to handle for formatting/consumer perspective.

Happy to also create a PR to the docs if this gets accepted :)