### PR TITLE
Add support for hyprland's new IPC event since v0.37.0 and change 'switch case' to map

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -84,8 +84,8 @@ export class Hyprland extends Service {
             'keyboard-layout': ['string', 'string'],
             'monitor-added': ['string'],
             'monitor-removed': ['string'],
-            'workspace-added': ['string'],
-            'workspace-removed': ['string'],
+            'workspace-added': ['int', 'string'],
+            'workspace-removed': ['int', 'string'],
             'client-added': ['string'],
             'client-removed': ['string'],
             'fullscreen': ['boolean'],
@@ -141,11 +141,8 @@ export class Hyprland extends Service {
         // this._syncWorkspaces();
         // this._syncClients();
 
-        const commitDate = JSON.parse(this.message('j/version')).commit_date;
-
-        this._eventActions.set(
-            commitDate >= '2024-3-16' ? 'workspacev2' : 'workspace',
-            async _ => await this._syncMonitors(),
+        this._eventActions.set('workspacev2', async _ =>
+            await this._syncMonitors(),
         );
 
         this._eventActions.set('focusedmon', async _ =>
@@ -162,19 +159,15 @@ export class Hyprland extends Service {
             this.emit('monitor-added', argv[0]);
         });
 
-        this._eventActions.set(
-            commitDate >= '2024-3-16' ? 'createworkspacev2' : 'createworkspace',
-            async argv => {
-                await this._syncWorkspaces();
-                this.emit('workspace-added', argv[0]);
-            });
+        this._eventActions.set('createworkspacev2', async argv => {
+            await this._syncWorkspaces();
+            this.emit('workspace-added', argv[0], argv[1]);
+        });
 
-        this._eventActions.set(
-            commitDate >= '2024-3-16' ? 'destroyworkspacev2' : 'destroyworkspace',
-            async argv => {
-                await this._syncWorkspaces();
-                this.emit('workspace-removed', argv[0]);
-            });
+        this._eventActions.set('destroyworkspacev2', async argv => {
+            await this._syncWorkspaces();
+            this.emit('workspace-removed', argv[0], argv[1]);
+        });
 
         this._eventActions.set('openwindow', async argv => {
             await this._syncClients(false);
@@ -183,13 +176,11 @@ export class Hyprland extends Service {
             this.emit('client-added', '0x' + argv[0]);
         });
 
-        this._eventActions.set(
-            commitDate >= '2024-3-16' ? 'movewindowv2' : 'movewindow',
-            async _ => {
-                await this._syncClients(false);
-                await this._syncWorkspaces(false);
-                ['clients', 'workspaces'].forEach(e => this.notify(e));
-            });
+        this._eventActions.set('movewindowv2', async _ => {
+            await this._syncClients(false);
+            await this._syncWorkspaces(false);
+            ['clients', 'workspaces'].forEach(e => this.notify(e));
+        });
 
         this._eventActions.set('windowtitle', async _ => {
             await this._syncClients(false);
@@ -197,14 +188,12 @@ export class Hyprland extends Service {
             ['clients', 'workspaces'].forEach(e => this.notify(e));
         });
 
-        this._eventActions.set(
-            commitDate >= '2024-3-16' ? 'moveworkspacev2' : 'moveworkspace',
-            async _ => {
-                await this._syncClients(false);
-                await this._syncWorkspaces(false);
-                await this._syncMonitors(false);
-                ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
-            });
+        this._eventActions.set('moveworkspacev2', async _ => {
+            await this._syncClients(false);
+            await this._syncWorkspaces(false);
+            await this._syncMonitors(false);
+            ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
+        });
 
         this._eventActions.set('fullscreen', async argv => {
             await this._syncClients(false);

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -140,8 +140,12 @@ export class Hyprland extends Service {
 
         // this._syncWorkspaces();
         // this._syncClients();
-        this._eventActions.set('workspace', async (argv) =>
-            await this._syncMonitors()
+
+        let commitDate = JSON.parse(this.message('j/version')).commit_date;
+
+        this._eventActions.set(
+            commitDate >= '2024-3-16' ? 'workspacev2' : 'workspace',
+            async (argv) => await this._syncMonitors()
         );
 
         this._eventActions.set('focusedmon', async (argv) =>
@@ -158,15 +162,19 @@ export class Hyprland extends Service {
             this.emit('monitor-added', argv[0]);
         });
 
-        this._eventActions.set('createworkspace', async (argv) => {
-            await this._syncWorkspaces();
-            this.emit('workspace-added', argv[0]);
-        });
+        this._eventActions.set(
+            commitDate >= '2024-3-16' ? 'createworkspacev2' : 'createworkspace',
+            async (argv) => {
+                await this._syncWorkspaces();
+                this.emit('workspace-added', argv[0]);
+            });
 
-        this._eventActions.set('destroyworkspace', async (argv) => {
-            await this._syncWorkspaces();
-            this.emit('workspace-removed', argv[0]);
-        });
+        this._eventActions.set(
+            commitDate >= '2024-3-16' ? 'destroyworkspacev2' : 'destroyworkspace',
+            async (argv) => {
+                await this._syncWorkspaces();
+                this.emit('workspace-removed', argv[0]);
+            });
 
         this._eventActions.set('openwindow', async (argv) => {
             await this._syncClients(false);
@@ -175,11 +183,13 @@ export class Hyprland extends Service {
             this.emit('client-added', '0x' + argv[0]);
         });
 
-        this._eventActions.set('movewindow', async (argv) => {
-            await this._syncClients(false);
-            await this._syncWorkspaces(false);
-            ['clients', 'workspaces'].forEach(e => this.notify(e));
-        });
+        this._eventActions.set(
+            commitDate >= '2024-3-16' ? 'movewindowv2' : 'movewindow',
+            async (argv) => {
+                await this._syncClients(false);
+                await this._syncWorkspaces(false);
+                ['clients', 'workspaces'].forEach(e => this.notify(e));
+            });
 
         this._eventActions.set('windowtitle', async (argv) => {
             await this._syncClients(false);
@@ -187,12 +197,14 @@ export class Hyprland extends Service {
             ['clients', 'workspaces'].forEach(e => this.notify(e));
         });
 
-        this._eventActions.set('moveworkspace', async (argv) => {
-            await this._syncClients(false);
-            await this._syncWorkspaces(false);
-            await this._syncMonitors(false);
-            ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
-        });
+        this._eventActions.set(
+            commitDate >= '2024-3-16' ? 'moveworkspacev2' : 'moveworkspace',
+            async (argv) => {
+                await this._syncClients(false);
+                await this._syncWorkspaces(false);
+                await this._syncMonitors(false);
+                ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
+            });
 
         this._eventActions.set('fullscreen', async (argv) => {
             await this._syncClients(false);

--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -141,42 +141,42 @@ export class Hyprland extends Service {
         // this._syncWorkspaces();
         // this._syncClients();
 
-        let commitDate = JSON.parse(this.message('j/version')).commit_date;
+        const commitDate = JSON.parse(this.message('j/version')).commit_date;
 
         this._eventActions.set(
             commitDate >= '2024-3-16' ? 'workspacev2' : 'workspace',
-            async (argv) => await this._syncMonitors()
+            async _ => await this._syncMonitors(),
         );
 
-        this._eventActions.set('focusedmon', async (argv) =>
-            await this._syncMonitors()
+        this._eventActions.set('focusedmon', async _ =>
+            await this._syncMonitors(),
         );
 
-        this._eventActions.set('monitorremoved', async (argv) => {
+        this._eventActions.set('monitorremoved', async argv => {
             await this._syncMonitors();
             this.emit('monitor-removed', argv[0]);
         });
 
-        this._eventActions.set('monitoradded', async (argv) => {
+        this._eventActions.set('monitoradded', async argv => {
             await this._syncMonitors();
             this.emit('monitor-added', argv[0]);
         });
 
         this._eventActions.set(
             commitDate >= '2024-3-16' ? 'createworkspacev2' : 'createworkspace',
-            async (argv) => {
+            async argv => {
                 await this._syncWorkspaces();
                 this.emit('workspace-added', argv[0]);
             });
 
         this._eventActions.set(
             commitDate >= '2024-3-16' ? 'destroyworkspacev2' : 'destroyworkspace',
-            async (argv) => {
+            async argv => {
                 await this._syncWorkspaces();
                 this.emit('workspace-removed', argv[0]);
             });
 
-        this._eventActions.set('openwindow', async (argv) => {
+        this._eventActions.set('openwindow', async argv => {
             await this._syncClients(false);
             await this._syncWorkspaces(false);
             ['clients', 'workspaces'].forEach(e => this.notify(e));
@@ -185,13 +185,13 @@ export class Hyprland extends Service {
 
         this._eventActions.set(
             commitDate >= '2024-3-16' ? 'movewindowv2' : 'movewindow',
-            async (argv) => {
+            async _ => {
                 await this._syncClients(false);
                 await this._syncWorkspaces(false);
                 ['clients', 'workspaces'].forEach(e => this.notify(e));
             });
 
-        this._eventActions.set('windowtitle', async (argv) => {
+        this._eventActions.set('windowtitle', async _ => {
             await this._syncClients(false);
             await this._syncWorkspaces(false);
             ['clients', 'workspaces'].forEach(e => this.notify(e));
@@ -199,32 +199,32 @@ export class Hyprland extends Service {
 
         this._eventActions.set(
             commitDate >= '2024-3-16' ? 'moveworkspacev2' : 'moveworkspace',
-            async (argv) => {
+            async _ => {
                 await this._syncClients(false);
                 await this._syncWorkspaces(false);
                 await this._syncMonitors(false);
                 ['clients', 'workspaces', 'monitors'].forEach(e => this.notify(e));
             });
 
-        this._eventActions.set('fullscreen', async (argv) => {
+        this._eventActions.set('fullscreen', async argv => {
             await this._syncClients(false);
             await this._syncWorkspaces(false);
             ['clients', 'workspaces'].forEach(e => this.notify(e));
             this.emit('fullscreen', argv[0] === '1');
         });
 
-        this._eventActions.set('activewindow', (argv) => {
+        this._eventActions.set('activewindow', argv => {
             this._active.client.updateProperty('class', argv[0]);
             this._active.client.updateProperty('title', argv.slice(1).join(','));
             this._active.client.emit('changed');
         });
 
-        this._eventActions.set('activewindowv2', (argv) => {
+        this._eventActions.set('activewindowv2', argv => {
             this._active.client.updateProperty('address', '0x' + argv[0]);
             this._active.client.emit('changed');
         });
 
-        this._eventActions.set('closewindow', async (argv) => {
+        this._eventActions.set('closewindow', async argv => {
             await this._syncWorkspaces(false);
             await this._syncClients(false);
             if (this._active.client.address === '0x' + argv[0]) {
@@ -237,19 +237,19 @@ export class Hyprland extends Service {
             this.emit('client-removed', '0x' + argv[0]);
         });
 
-        this._eventActions.set('urgent', (argv) => {
+        this._eventActions.set('urgent', argv => {
             this.emit('urgent-window', '0x' + argv[0]);
         });
 
-        this._eventActions.set('activelayout', (argv) => {
+        this._eventActions.set('activelayout', argv => {
             this.emit('keyboard-layout', `${argv[0]}`, `${argv[1]}`);
         });
 
-        this._eventActions.set('changefloatingmode', async (argv) => {
+        this._eventActions.set('changefloatingmode', async _ => {
             await this._syncClients();
         });
 
-        this._eventActions.set('submap', (argv) => {
+        this._eventActions.set('submap', argv => {
             this.emit('submap', argv[0]);
         });
 
@@ -380,10 +380,9 @@ export class Hyprland extends Service {
         const argv = params.split(',');
 
         try {
-            let action = this._eventActions.get(e);
+            const action = this._eventActions.get(e);
             if (action)
                 action(argv);
-
         } catch (error) {
             if (error instanceof Error)
                 console.error(error.message);


### PR DESCRIPTION
This pr changes the 'switch case' code structure to a Map of events to callbacks, which will slightly improve performace and make it convenient for the following changes.

On top of that, it adds support for hyprland's new IPC event since v0.37.0.
If Hyprland's version is greater than v0.37.0 (if the commit date is after 2024-3-16), then
`workspacev2`, `createworkspacev2`, `destoryworkspacev2`, `movewindowv2`, `moveworkspacev2`
is listend instead of their non-v2 versions.

Note that under `createworkspacev2` and `destoryworkspacev2`, `workspace-added` and
`workspace-removed` signal return workspace's id, not name.