### PR TITLE
fix: append notification instead of prepend in notifications popup example

### DIFF
--- a/example/notification-popups/notificationPopups.js
+++ b/example/notification-popups/notificationPopups.js
@@ -98,7 +98,7 @@ export function NotificationPopups(monitor = 0) {
     function onNotified(_, /** @type {number} */ id) {
         const n = notifications.getNotification(id)
         if (n)
-            list.children = [Notification(n), ...list.children]
+            list.children = [...list.children, Notification(n)]
     }
 
     function onDismissed(_, /** @type {number} */ id) {


### PR DESCRIPTION
I believe the notification should be added at the end of the notifications list, this way the oldest notifications are destroyed first, instead of the newest ones.

I was using this example in my dotfiles when I noticed this and this change made it work for me. If you feel this change is not necessary or not a suitable solution, simply close this.