### PR TITLE
Fix example applauncher: press ENTER triggers only filtered items

### DIFF
--- a/example/applauncher/applauncher.js
+++ b/example/applauncher/applauncher.js
@@ -53,7 +53,7 @@ const Applauncher = ({ width = 500, height = 500, spacing = 12 }) => {
 	    const results = applications.filter((item) => item.visible);
             if (results[0]) {
                 App.toggleWindow(WINDOW_NAME)
-                applications[0].attribute.app.launch()
+                results[0].attribute.app.launch()
             }
         },
 


### PR DESCRIPTION
I noticed a bug in the example for the app launcher. This change makes it work as expected.

On a side note, I wonder if it's possible to change focus using alternative keys. I am a heavy Emacs user and would like CTRL + N / P to move up and down the list.
