### PR TITLE
fix(network): handling multiple adapters

### DIFF
--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -501,9 +501,11 @@ export class Network extends Service {
     };
 
     private _getDevice(devType: NM.DeviceType) {
-        return this._client
+        const valid_devices = this._client
             .get_devices()
-            .find(device => device.get_device_type() === devType);
+            .filter(device => device.get_device_type() === devType);
+
+        return valid_devices.find(d => d.active_connection !== null) || valid_devices.at(0);
     }
 
     private _clientReady() {


### PR DESCRIPTION
When there are two Ethernet devices available (one built-in and the other through a docking station), the current implementation picks up the built-in one (the earlier one) instead of picking the device with an active connection.

With the new behavior, we give preference to the device with an active connection, if not, we default to our earlier behavior of returning the first device that's available.