### PR TITLE
fix(hyprland): look for new location of socket

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -4,6 +4,9 @@ import Service from '../service.js';
 
 Gio._promisify(Gio.DataInputStream.prototype, 'read_upto_async');
 const HIS = GLib.getenv('HYPRLAND_INSTANCE_SIGNATURE');
+const RUN = GLib.getenv('XDG_RUNTIME_DIR');
+const SOCKET_PATH = GLib.file_test(`${RUN}/hypr/${HIS}`, GLib.FileTest.EXISTS) ?
+    `${RUN}/hypr/${HIS}` : `/tmp/hypr/${HIS}`;
 
 const socket = (path: string) => new Gio.SocketClient()
     .connect(new Gio.UnixSocketAddress({ path }), null);
@@ -142,7 +145,7 @@ export class Hyprland extends Service {
 
         this._watchSocket(new Gio.DataInputStream({
             close_base_stream: true,
-            base_stream: socket(`/tmp/hypr/${HIS}/.socket2.sock`)
+            base_stream: socket(`${SOCKET_PATH}/.socket2.sock`)
                 .get_input_stream(),
         }));
 
@@ -168,7 +171,7 @@ export class Hyprland extends Service {
     };
 
     private _socketStream(cmd: string) {
-        const connection = socket(`/tmp/hypr/${HIS}/.socket.sock`);
+        const connection = socket(`${SOCKET_PATH}/.socket.sock`);
 
         connection
             .get_output_stream()


### PR DESCRIPTION
Keeping up with this commit from hyprland: https://github.com/hyprwm/Hyprland/commit/a5a648091760ac002120fab18247e5292b6482de
> For consumers, check if `$XDG_RUNTIME_DIR/hypr` exists. If so, use it. If not, use the old `/tmp/hypr`.