### PR TITLE
Add a simple DBus service for setting a status 

### DIFF
--- a/src/com.github.Aylur.ags.src.gresource.xml
+++ b/src/com.github.Aylur.ags.src.gresource.xml
@@ -55,10 +55,12 @@
     <file>service/notifications.js</file>
     <file>service/powerprofiles.js</file>
     <file>service/systemtray.js</file>
+    <file>service/statusdbus.js</file>
 
     <file>dbus/types.js</file>
     <file>dbus/com.github.Aylur.ags.xml</file>
     <file>dbus/com.github.Aylur.ags.client.xml</file>
+    <file>dbus/com.github.Aylur.ags.status.xml</file>
     <file>dbus/net.hadess.PowerProfiles.xml</file>
     <file>dbus/org.freedesktop.DBus.xml</file>
     <file>dbus/org.freedesktop.Notifications.xml</file>

--- a/src/dbus/com.github.Aylur.ags.status.xml
+++ b/src/dbus/com.github.Aylur.ags.status.xml
@@ -1,0 +1,7 @@
+<node>
+    <interface name="com.github.Aylur.ags.status">
+        <method name="Set">
+            <arg direction="in" type="s" name="string"/>
+        </method>
+    </interface>
+</node>

--- a/src/service.ts
+++ b/src/service.ts
@@ -52,6 +52,7 @@ interface Services {
     powerprofiles: typeof import('./service/powerprofiles.js').default
     systemtray: typeof import('./service/systemtray.js').default
     greetd: typeof import('./service/greetd.js').default
+    statusdbus: typeof import('./service/statusdbus.js').default
 }
 
 export default class Service extends GObject.Object {

--- a/src/service/statusdbus.ts
+++ b/src/service/statusdbus.ts
@@ -1,0 +1,49 @@
+import Gio from 'gi://Gio';
+import Service from '../service.js';
+import { loadInterfaceXML } from "../utils.js";
+
+const StatusDbusIFace = loadInterfaceXML('com.github.Aylur.ags.status')!;
+
+
+export class StatusDbus extends Service {
+  static {
+    Service.register(this, {
+      'status_changed': ['string'],
+    },
+    )
+  };
+
+  private _status = '';
+  private _dbus!: Gio.DBusExportedObject;
+
+  get status() { return this._status; }
+
+  constructor() {
+    super();
+    this._register();
+  }
+
+  private _register() {
+    Gio.bus_own_name(
+      Gio.BusType.SESSION,
+      'com.github.Aylur.ags.status',
+      Gio.BusNameOwnerFlags.NONE,
+      (connection: Gio.DBusConnection) => {
+        this._dbus = Gio.DBusExportedObject
+          .wrapJSObject(StatusDbusIFace as string, this);
+        this._dbus.export(connection, '/com/github/Aylur/ags/status');
+      },
+      null,
+      null,
+    )
+
+  }
+
+  Set(status: string) {
+    this._status = status;
+    this.emit('status_changed', status);
+  }
+}
+
+export const statusDbus = new StatusDbus;
+export default statusDbus;


### PR DESCRIPTION
Hi!

I'm missing  [custom_dbus](https://docs.rs/i3status-rs/latest/i3status_rs/blocks/custom_dbus/index.html) from another project and I'd like to add it here.

My motivation: sync a pomodoro timer app with status bar by providing custom hooks on timer events. In this case bar does not need to constantly poll for some resource, which I think is nice.

Would you be interested in this feature?