### PR TITLE
fix: active workspace sync error

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -223,13 +223,22 @@ export class Hyprland extends Service {
                 this._monitors.set(m.id, m);
                 if (m.focused) {
                     this._active.monitor.update(m.id, m.name);
-                    this._active.workspace.update(m.activeWorkspace.id, m.activeWorkspace.name);
                     this._active.monitor.emit('changed');
-                    this._active.workspace.emit('changed');
                 }
             }
             if (notify)
                 this.notify('monitors');
+        } catch (error) {
+            logError(error);
+        }
+    }
+
+    private _updateActiveWorksapce(id: number, name: string, notify = true) {
+        try {
+            this._active.workspace.update(id, name);
+            this._active.workspace.emit('changed');
+            if (notify)
+                this.notify('workspaces');
         } catch (error) {
             logError(error);
         }
@@ -272,7 +281,9 @@ export class Hyprland extends Service {
 
         try {
             switch (e) {
-                case 'workspace':
+                case 'workspacev2':
+                    this._updateActiveWorksapce(Number(argv[0]), argv[1]);
+                    break;
                 case 'focusedmon':
                     await this._syncMonitors();
                     break;


### PR DESCRIPTION
Related #449
Use hyprland socket2 event to update active workspace now. on my PC it doesn't cause `Resource temporarily unavailable` issue now.