### PR TITLE
Feature: add an optional option to the --toggle-window argument to allow the user to explicitly show/hide windows

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -400,8 +400,21 @@ export class App extends Gtk.Application {
             });
     }
 
-    ToggleWindow(name: string) {
-        this.toggleWindow(name);
+    ToggleWindow(name: string, toggleType: string = "toggle") {
+        switch(toggleType) {
+            case "toggle":
+                this.toggleWindow(name);
+                break;
+            case "show":
+                if (!this.getWindow(name)?.visible) this.openWindow(name);
+                break;
+            case "hide":
+                if (this.getWindow(name)?.visible) this.closeWindow(name);
+                break;
+            default:
+                console.error(`unknown toggleType: ${toggleType}`);
+                break;
+        }
         return `${this.getWindow(name)?.visible}`;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,7 @@ interface Flags {
     runJs: string
     runFile: string
     toggleWindow: string
+    toggleType: string
     quit: boolean
 
     // FIXME: deprecated
@@ -96,7 +97,7 @@ export default function(bus: string, path: string, flags: Flags) {
     const client = new Client(bus, path, proxy);
 
     if (flags.toggleWindow)
-        print(proxy.ToggleWindowSync(flags.toggleWindow));
+        print(proxy.ToggleWindowSync(flags.toggleWindow, flags.toggleType));
 
     else if (flags.runJs)
         client.remote('Js', flags.runJs);

--- a/src/dbus/com.github.Aylur.ags.xml
+++ b/src/dbus/com.github.Aylur.ags.xml
@@ -4,6 +4,7 @@
         <method name='Quit'/>
         <method name="ToggleWindow">
             <arg direction="in" type="s" name="name"/>
+            <arg direction="in" type="s" name="toggle-type"/>
             <arg direction="out" type="s" name="state"/>
         </method>
         <method name="RunJs">

--- a/src/dbus/types.ts
+++ b/src/dbus/types.ts
@@ -75,7 +75,10 @@ export interface AgsProxy extends Gio.DBusProxy {
     new(...args: unknown[]): AgsProxy;
     InspectorRemote: () => void;
     QuitRemote: () => void;
-    ToggleWindowSync: (name: string) => boolean;
+    ToggleWindowSync: (
+        name: string, 
+        toggleType?: string
+    ) => boolean;
     RunFileRemote: (
         js: string,
         busName?: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ OPTIONS:
     -c, --config            Path to the config file. Default: ${DEFAULT_CONF}
     -b, --bus-name          Bus name of the process
     -i, --inspector         Open up the Gtk debug tool
-    -t, --toggle-window     Show or hide a window
+    -t, --toggle-window     Show (--show), hide (--hide), or toggle (--toggle) a window. USAGE: "-t window_name [option]". Default option is toggle
     -r, --run-js            Execute string as an async function
     -f, --run-file          Execute file as an async function
     --init                  Initialize the configuration directory
@@ -35,6 +35,7 @@ export async function main(args: string[]) {
         runJs: '',
         runFile: '',
         toggleWindow: '',
+        toggleType: 'toggle',
         quit: false,
         init: false,
 
@@ -108,6 +109,13 @@ export async function main(args: string[]) {
             case '-t':
             case '--toggle-window':
                 flags.toggleWindow = args[++i];
+                switch (args[i+1]) {
+                    case '--toggle':
+                    case '--show':
+                    case '--hide':
+                        flags.toggleType = args[++i].replace(/^--/,"");
+                        break;
+                }
                 break;
 
             case 'quit':


### PR DESCRIPTION
I added an argument that takes the form:

`ags {-t/--toggle-window} {window} [--show/--hide/--toggle/]`

You don't have to take this feature, but I wanted it for Hyprland setup and it might be useful to others. If you want me to rework anything let me know :)