### PR TITLE
hyprland: Add tags to the `Client` type

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -455,6 +455,7 @@ export interface Client {
     fullscreenMode: number
     fakeFullscreen: boolean
     grouped: [string],
+    tags: string[]
     swallowing: string
     focusHistoryID: number
 }


### PR DESCRIPTION
Just a quick edit to keep types up to date, I don't think anything else needs to be added

Reference from wiki: https://wiki.hyprland.org/Configuring/Window-Rules/#tags

Example of usage from my config: https://github.com/pynappo/dotfiles/blob/5e62a0c0ecf148fb7e835ed05444549258c8f4bd/.config/ags/bar.ts#L149