### PR TITLE
post_install.sh: create ags symlink relative to Root directory

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -9,7 +9,7 @@ mkdir -p $BIN_DIR
 
 BIN_SRC="$PKGDATA_DIR/$APP_ID"
 BIN_DEST="$BIN_DIR/ags"
-ln -s -f $BIN_SRC $BIN_DEST
+ln -s -r -f $BIN_SRC $BIN_DEST
 
 if [[ "$5" == "false" ]]; then
 	exit 0


### PR DESCRIPTION
This bug was reported by a Gentoo user: https://github.com/gentoo/guru/pull/212

Creating the ags executable as an absolute symlink to `$DESTDIR/$2/$APP_ID` breaks staged installs, where the installed files are not placed directly into their expected location but are instead copied into a temporary location (`DESTDIR`). Since installed files maintain their relative directory structure and any embedded file names will not be modified, we can create a relative symlink instead, which fixes the issue.

It has the added benefit that the link target remains valid, even if the storage device underlying this program is mounted into a subdirectory of the root filesystem (e.g. for recovery).

