### PR TITLE
Fix MenuItemProps.Properties typo

### DIFF
--- a/src/widgets/menuitem.ts
+++ b/src/widgets/menuitem.ts
@@ -11,7 +11,7 @@ export type MenuItemProps<
     child?: Child
     on_activate?: Event<Self>
     on_select?: Event<Self>
-    on_deselct?: Event<Self>
+    on_deselect?: Event<Self>
 }, Attr>
 
 export function newMenuItem<


### PR DESCRIPTION
I found this typo while making my custom bar.

![image](https://github.com/user-attachments/assets/f8f7c750-44ce-416f-a136-713fc0b422bf)

May be not actually relevant due to #504