### PR TITLE
Nix Housekeeping

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -6,19 +6,19 @@ jobs:
     name: "Build"
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    - uses: cachix/install-nix-action@v25
-    - uses: DeterminateSystems/magic-nix-cache-action@main
-    - uses: cachix/cachix-action@v12
-      with:
-        name: ags
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: cachix/install-nix-action@v25
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
+        with:
+          name: ags
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-    - name: Build ags
-      run: |
-        nix build --print-build-logs
-        nix build --print-build-logs .#agsWithTypes
+      - name: Build ags
+        run: |
+          nix build --print-build-logs
+          nix build --print-build-logs .#agsWithTypes

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,17 +3,18 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # «https://github.com/nix-systems/nix-systems»
+    systems.url = "github:nix-systems/default-linux";
   };
 
   outputs = {
     nixpkgs,
     self,
+    systems,
   }: let
     version = builtins.replaceStrings ["\n"] [""] (builtins.readFile ./version);
-    genSystems = nixpkgs.lib.genAttrs [
-      "aarch64-linux"
-      "x86_64-linux"
-    ];
+    genSystems = nixpkgs.lib.genAttrs (import systems);
     pkgs = genSystems (system: import nixpkgs {inherit system;});
   in {
     packages = genSystems (system: rec {


### PR DESCRIPTION
**flake**
- Gets rid of a few bad `rec` patterns
- Allows users to override Ags' flake systems
- Adds `homeManagerModules.ags` and aliases `homeManagerModules.default` to it

**package**
- Gets rid of a few bad `rec` patterns
- Uses `lib.strings.mesonBool` instead of an if else exp
- Adds missing preInstall and postInstall hooks
- Gets rid of nested `with lib;` and adds changelog
- Uses `alejandra` formatter for consistency
  - TODO: add a default formatter?

**other**
- Minor cleanup in the CI


Nothing in the functionality has changed, this PR just makes it easier to read and maintain Nix code.