### PR TITLE
ags: added systemd to run in NixOs

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -68,5 +68,25 @@ in {
       home.packages = [pkg];
       home.file.".local/${path}".source = "${pkg}/${path}";
     }))
+    {
+      systemd.user.services.ags = {
+        Unit = {
+          Description = "AGS - A library built for GJS to allow defining GTK widgets in a declarative way.";
+          Documentation = "https://github.com/Aylur/ags";
+          PartOf = ["graphical-session.target"];
+          After = ["graphical-session-pre.target"];
+        };
+
+        Service = {
+          ExecStart = "${config.programs.ags.package}/bin/ags -b hypr";
+          Restart = "on-failure";
+          KillMode = "mixed";
+        };
+
+        Install = {
+          WantedBy = ["graphical-session.target"];
+        };
+      };
+    }
   ]);
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -51,6 +51,16 @@ in {
       '';
       example = literalExpression "[ pkgs.libsoup_3 ]";
     };
+
+    systemd.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Enable systemd integration.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -60,14 +70,16 @@ in {
     (mkIf (cfg.package != null) (let
       path = "/share/com.github.Aylur.ags/types";
       pkg = cfg.package.override {
-        extraPackages = cfg.extraPackages;
+extraPackages = cfg.extraPackages;
         buildTypes = true;
       };
     in {
       programs.ags.finalPackage = pkg;
       home.packages = [pkg];
       home.file.".local/${path}".source = "${pkg}/${path}";
-    }))
+    })
+    )
+    (mkIf cfg.systemd.enable (
     {
       systemd.user.services.ags = {
         Unit = {
@@ -87,6 +99,5 @@ in {
           WantedBy = ["graphical-session.target"];
         };
       };
-    }
+    }))
   ]);
-}


### PR DESCRIPTION

Now, enabling the module runs AGS without the need to add the following line:
```
exec-once = with pkgs; [
  #"${config.programs.ags.package}/bin/ags -b hypr"
];
```
This approach aligns more closely with the Nix philosophy imo, rather than running it inside the Hyprland (or any other WM) module. Many other packages, such as `hyprpaper` and `swaync`, follow this approach.