### PR TITLE
Fix path parsing in cli tool

### DIFF
--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -20,8 +20,8 @@ export function isRunning(dbusName: string, bus: 'session' | 'system') {
 }
 
 export function parsePath(path: string) {
-    return path.startsWith('.')
-        ? `${GLib.getenv('PWD')}${path.slice(1)}`
+    return path.startsWith('./')
+        ? `${GLib.getenv('PWD')}/${path.slice(2)}`
         : path;
 }
 


### PR DESCRIPTION
- fix relative path with dot directories
- add posibility to use relative paths without starting symbols like "ags/config.js"
- inform user that parent relative path is not supported