### PR TITLE
nix: minor cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718714799,
-        "narHash": "sha256-FUZpz9rg3gL8NVPKbqU8ei1VkPLsTIfAJ2fdAf5qjak=",
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,7 +13,7 @@
   gjs,
   wrapGAppsHook,
   upower,
-  gnome,
+  gnome-bluetooth,
   gtk-layer-shell,
   glib-networking,
   networkmanager,
@@ -74,7 +74,7 @@ in
         gtk3
         libpulseaudio
         upower
-        gnome.gnome-bluetooth
+        gnome-bluetooth
         gtk-layer-shell
         glib-networking
         networkmanager

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -41,7 +41,11 @@ in
 
     src = buildNpmPackage {
       name = pname;
-      src = lib.cleanSource ../.;
+
+      src = builtins.path {
+        name = "ags-${version}";
+        path = lib.cleanSource ../.;
+      };
 
       dontBuild = true;
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -108,6 +108,7 @@ in
       changelog = "https://github.com/Aylur/ags/blob/${version}/CHANGELOG.md";
       platforms = ["x86_64-linux" "aarch64-linux"];
       license = lib.licenses.gpl3;
-      meta.maintainers = [lib.maintainers.Aylur];
+      mainProgram = "ags";
+      maintainers = [lib.maintainers.Aylur];
     };
   }


### PR DESCRIPTION
Makes the source path reproducible, and fixes the eval warning in newer nixpkgs versions due to  gnome-bluetooth moving to a top-level package. Also fixes getExe by setting mainProgram manually, which helps write systemd services better.

Supersedes #510