### PR TITLE
Syntax error, missing curly brace, small fix to hm-module.nix

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -101,3 +101,4 @@ extraPackages = cfg.extraPackages;
       };
     }))
   ]);
+}


### PR DESCRIPTION
There is a syntax error with a missing curly brace and the end of the file, causing nixos to throw unexpected end of line errors