### PR TITLE
fix: update hyprland workspaces on workspace change (#418, #514)

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -284,6 +284,7 @@ export class Hyprland extends Service {
                 case 'workspace':
                 case 'focusedmon':
                     await this._syncMonitors();
+                    await this._syncWorkspaces();
                     break;
 
                 case 'monitorremoved':


### PR DESCRIPTION
Quick one-liner fix. Syncs hyprland workspaces on workspace change, making the `lastwindow` workspace property behave properly.
Fixes #418 
Fixes #514 