### PR TITLE
fix: set astal lib path when using /usr/local install.

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -107,10 +107,12 @@ func run() {
 
 	outfile := getOutfile()
 	Build(infile, outfile)
+	astalLib := "GI_TYPELIB_PATH=" + filepath.Join(astalGjs, "../../../lib64/girepository-1.0")
 	cmd := Exec("gjs", "-m", outfile)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
+	cmd.Env = append(cmd.Environ(), astalLib)
 	cmd.Dir = *Opts.config
 
 	// TODO: watch and restart


### PR DESCRIPTION
### Issues 

Couldn't start ags when using /usr/local install path

```
(gjs:22607): Gjs-CRITICAL **: 14:38:46.308: JS ERROR: Error: Requiring Astal, version 0.1: Typelib file for namespace 'Astal', version '0.1' not found
require@resource:///org/gnome/gjs/modules/esm/gi.js:16:28
@gi://Astal/?version=0.1:3:25


(gjs:22607): Gjs-CRITICAL **: 14:38:46.308: Module file:///run/user/1000/ags.js threw an exception
error: exit status 1
```

### Solutions

Manually set gjs lib path environment variable.