### PR TITLE
fix(mpris): add delay before adding new player

### DIFF
--- a/src/service/mpris.ts
+++ b/src/service/mpris.ts
@@ -1,7 +1,7 @@
 import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 import Service from '../service.js';
-import { ensureDirectory, idle } from '../utils.js';
+import { ensureDirectory, idle, timeout } from '../utils.js';
 import { CACHE_DIR } from '../utils.js';
 import { loadInterfaceXML } from '../utils.js';
 import { DBusProxy, PlayerProxy, MprisProxy } from '../dbus/types.js';
@@ -368,7 +368,7 @@ export class Mpris extends Service {
             return;
 
         if (newOwner && !oldOwner)
-            this._addPlayer(name);
+            timeout(500, this._addPlayer.bind(this, name));
     }
 
     readonly getPlayer = (name = '') => {


### PR DESCRIPTION
The mpris dbus of some poorly implemented players (cough Netease Cloud Music cough) may not be ready when it's published. Immediately initializing the dbus proxy results in a race condition and leads to failure. Added a 500ms timeout to ensure that the player is properly initialized before being added.