### PR TITLE
feat: Remove the need for specifying the path to Astal in tsconfig.json

### DIFF
--- a/src/data/tsconfig.json
+++ b/src/data/tsconfig.json
@@ -11,15 +11,6 @@
         "skipLibCheck": true,
         "checkJs": true,
         "allowJs": true,
-        "jsx": "react-jsx",
-        "jsxImportSource": "@ASTAL_GJS@/src/jsx",
-        "paths": {
-            "astal": [
-                "@ASTAL_GJS@"
-            ],
-            "astal/*": [
-                "@ASTAL_GJS@/src/*"
-            ]
-        },
+        "jsx": "react-jsx"
     }
 }

--- a/src/init.go
+++ b/src/init.go
@@ -4,12 +4,9 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"strings"
 )
 
 var (
-	astalGjs = "/usr/share/astal/gjs"
-
 	//go:embed data/env.d.ts
 	envdts string
 
@@ -65,13 +62,12 @@ func InitConfig() {
 		Err("could not initialize: " + Cyan(config) + " is not empty")
 	}
 
-	tsconf := strings.ReplaceAll(tsconfig, "@ASTAL_GJS@", astalGjs)
 	appfile, bar := getConfig(true)
 
 	Mkdir(config + "/widget")
 
 	WriteFile(config+"/.gitignore", "@girs/\nnode_modules/")
-	WriteFile(config+"/tsconfig.json", tsconf)
+	WriteFile(config+"/tsconfig.json", tsconfig)
 	WriteFile(config+"/env.d.ts", envdts)
 	WriteFile(config+"/style.css", style)
 	WriteFile(config+"/widget/"+bar.name, bar.content)


### PR DESCRIPTION
On NixOS, you would have to edit tsconfig.json and update `compilerOptions.paths.astal`, `compilerOptions.paths."astal/*"`, and `compilerOptions.jsxImportSource` every time Astal gets an update and the old paths get garbage collected. Also, if you installed Astal to a non-standard location(e.g., /usr/ or somewhere in /nix/store), cloning someone else's dots wouldn't work out of the box. This PR inserts those paths into TsconfigRaw automatically. You still have to compile AGS with the ldflags stuff