### PR TITLE
nix: add fallback mirror https://github.com/GNOME/libgnome-volume-con…

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,6 +3,8 @@
   stdenv,
   buildNpmPackage,
   fetchFromGitLab,
+  fetchFromGitHub,
+  fetchzip,
   nodePackages,
   meson,
   pkg-config,
@@ -28,7 +30,23 @@
 }: let
   pname = "ags";
 
-  gvc-src = fetchFromGitLab {
+  getGnomeZip = {
+    domain,
+    repo,
+    rev,
+    owner,
+    sha256,
+    ...
+  }:
+    fetchzip {
+      urls = [
+        ((fetchFromGitLab {inherit rev repo owner domain;}).url)
+        ((fetchFromGitHub {inherit rev repo owner;}).url)
+      ];
+      inherit sha256;
+    };
+
+  gvc-src = getGnomeZip {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "libgnome-volume-control";


### PR DESCRIPTION
When trying to fetch updates from https://gitlab.gnome.org/GNOME/libgnome-volume-control, I encountered a 404 error. I also experienced a 500 error when opening it in the browser (though I don't remember the specific error). It seems to be working now.

I found the official mirror of the repository at https://github.com/GNOME/libgnome-volume-control. It would be a good idea to add this as a fallback for the future.