### PR TITLE
fix(nix): run ags correctly in systemd service

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -125,7 +125,7 @@ in {
         };
 
         Service = {
-          ExecStart = "${cfg.finalPackage}/bin/ags";
+          ExecStart = "${cfg.finalPackage}/bin/ags run";
           Restart = "on-failure";
           KillMode = "mixed";
         };


### PR DESCRIPTION
v2 require to `run` sub-command for running