### PR TITLE
Changed overrideAttrs to override in the nix docs

### DIFF
--- a/docs/guide/nix.md
+++ b/docs/guide/nix.md
@@ -70,7 +70,7 @@ Or define a `devShell` and cherry pick packages.
     devShells.${system}.default = pkgs.mkShell {
       buildInputs = [
         # includes astal3 astal4 astal-io by default
-        (ags.packages.${system}.default.overrideAttrs { # [!code focus:5]
+        (ags.packages.${system}.default.override { # [!code focus:5]
           extraPackages = [
             # cherry pick packages
           ];

--- a/nix/template/flake.nix
+++ b/nix/template/flake.nix
@@ -40,7 +40,7 @@
           # ags.packages.${system}.agsFull
 
           # includes astal3 astal4 astal-io by default
-          (ags.packages.${system}.default.overrideAttrs {
+          (ags.packages.${system}.default.override {
             extraPackages = [
               # cherry pick packages
             ];


### PR DESCRIPTION
Fixes #622, fixes #629 

Nix devShell should use `override` instead of `overrideAttrs` since `extraPackages` is just a parameter we're changing, instead of having to change anything in the derivation itself.

From ags's `default.nix`:
```
{
  # other params
  extraPackages ? []
}: 
  ...
  buildInputs =
    extraPackages
    ++ [
      glib
      astal-io
      astal3
      astal4
    ];
```

 [override](https://nixos.org/manual/nixpkgs/stable/#sec-pkg-override) vs [overrideAttrs](https://nixos.org/manual/nixpkgs/stable/#sec-pkg-overrideAttrs).