### PR TITLE
chore(nix): add meta.mainProgram to lib.bundle

### DIFF
--- a/nix/bundle.nix
+++ b/nix/bundle.nix
@@ -55,4 +55,6 @@ pkgs.stdenvNoCC.mkDerivation {
 
     runHook postInstall
   '';
+  
+  meta.mainProgram = name;
 }


### PR DESCRIPTION
Just so we can use `lib.getExe` on bundle derivations.