### PR TITLE
Update nix.md

### DIFF
--- a/docs/guide/nix.md
+++ b/docs/guide/nix.md
@@ -140,9 +140,13 @@ Example content of `home.nix` file
 
     # additional packages to add to gjs's runtime
     extraPackages = with pkgs; [
-      inputs.ags.packages.${pkgs.system}.battery
+      # declare your additional packages here...
       fzf
-    ];
+    ] ++ (with inputs.ags.packages.${pkgs.system}; [
+        # declare your additional libraries here...
+        battery
+        wireplumber
+    ]);
   };
 }
 ```


### PR DESCRIPTION
- Separate the additional packages and additional libraries declaration in the home.nix section by using a `with` expression (which also removes the need to write `inputs.ags.packages.${pkgs.system}` every new library the user would want to add)

- Add an example for a library containing two uppercase letters in it's name (`WirePlumber` becomes `wireplumber`, not `wirePlumber`, or such)