### PR TITLE
docs: edit docs/guide/nix.md

### DIFF
--- a/docs/guide/nix.md
+++ b/docs/guide/nix.md
@@ -6,6 +6,24 @@ Initialize a directory using the template.
 nix flake init --template github:aylur/ags
 ```
 
+For activating **binary cache** add next lines to your configuration.
+
+```Nix
+{
+  nix.settings = {
+    substituters = [
+      "https://ags.cachix.org"
+    ];
+    trusted-public-keys = [
+      "ags.cachix.org-1:naAvMrz0CuYqeyGNyLgE010iUiuf/qx6kYrUv3NwAJ8="
+    ];
+  };
+}
+```
+
+> [!TIP]
+> This works with `home-manager` too! 
+
 ## Bundle and DevShell
 
 The flake exposes a `lib.bundle` function which can bundle your projects.


### PR DESCRIPTION
basically adding binary cache that's already in `Aylur/ags` but haven't been described in docs.
i've tested this on my own machines (pc + laptop), and used for 2 weeks +.
also fixed wrong `trusted-public-keys`, what i've mistyped and committed (sorry!).

fixes: #632 