### PR TITLE
Update flake.lock to fix building `astal-cava`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731952585,
-        "narHash": "sha256-Sh1E7sJd8JJM3PCU1ZOei/QWz97OLCENIi2rTRoaniw=",
+        "lastModified": 1733520119,
+        "narHash": "sha256-6K07ZJTnFu1xASBCMtVc9cFTbBEauwSc7gGBmjLkLSk=",
         "owner": "aylur",
         "repo": "astal",
-        "rev": "664c7a4ddfcf48c6e8accd3c33bb94424b0e8609",
+        "rev": "4c19d8d06fa25cc6389f37abe8839b4d8be5c0d6",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1733581040,
+        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
When running `nix shell github:aylur/ags#agsFull` as described in the [wiki](https://aylur.github.io/ags/guide/nix.html#bundle-and-devshell), the evaluation fails when building `cava` ( see https://github.com/Aylur/astal/issues/100 for details). The fix for this was recently merged into `nixpkgs-unstable`: https://github.com/NixOS/nixpkgs/pull/355948, meaning a flake lock update was required for a successful `ags` build. 

Notably, building `cava` in Astal specifically worked just fine (tested with `nix build github:aylur/astal#cava`). Since the Astal input in the flake follows AGS' `nixpkgs` it seems the breaking change happened somewhere in the middle. 