### PR TITLE
feat(nix): lib.wrap function

### DIFF
--- a/docs/guide/nix.md
+++ b/docs/guide/nix.md
@@ -71,7 +71,7 @@ Or define a `devShell` and cherry pick packages.
     devShells.${system}.default = pkgs.mkShell {
       buildInputs = [
         # includes astal3 astal4 astal-io by default
-        (ags.packages.${system}.default.override { # [!code focus:5]
+        (ags.packages.${system}.default.wrap { # [!code focus:5]
           extraPackages = [
             # cherry pick packages
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,7 @@
     systems = ["x86_64-linux" "aarch64-linux"];
     forAllSystems = nixpkgs.lib.genAttrs systems;
   in {
-    lib.bundle = import ./nix/bundle.nix {
-      inherit self;
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    };
+    lib.bundle = import ./nix/bundle.nix {inherit self;};
 
     packages = forAllSystems (
       system: let
@@ -29,13 +26,13 @@
         astal-io = io;
         astal-gjs = "${gjs}/share/astal/gjs";
 
-        agsPackages = {
-          default = self.packages.${system}.ags;
-          ags = pkgs.callPackage ./nix {
+        agsPackages = rec {
+          default = ags;
+          ags = pkgs.callPackage ./nix/default.nix {
             inherit astal3 astal4 astal-io astal-gjs;
+            wrap = import ./nix/wrap.nix { inherit pkgs ags; };
           };
-          agsFull = pkgs.callPackage ./nix {
-            inherit astal3 astal4 astal-io astal-gjs;
+          agsFull = ags.wrap {
             extraPackages = builtins.attrValues (
               builtins.removeAttrs astal.packages.${system} ["docs"]
             );

--- a/nix/bundle.nix
+++ b/nix/bundle.nix
@@ -1,8 +1,7 @@
 {
   self,
-  pkgs,
 }: {
-  pkgs ? pkgs,
+  pkgs,
   entry ? "app.ts",
   src,
   name,

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -15,7 +15,7 @@
   dart-sass,
   blueprint-compiler,
   installShellFiles,
-  extraPackages ? [],
+  wrap,
 }: let
   inherit (builtins) replaceStrings readFile;
 
@@ -33,12 +33,10 @@
     blueprint-compiler
     astal-io # FIXME: should not be needed after the astal commends are properly implemented using dbus in astal.go
   ];
-
-  version = replaceStrings ["\n"] [""] (readFile ../version);
-  pname = "ags";
 in
-  buildGoModule {
-    inherit pname version;
+  buildGoModule rec {
+    pname = "ags";
+    version = replaceStrings ["\n"] [""] (readFile ../version);
 
     src = builtins.path {
       name = "${pname}-${version}";
@@ -54,19 +52,17 @@ in
       installShellFiles
     ];
 
-    buildInputs =
-      extraPackages
-      ++ [
-        glib
-        astal-io
-        astal3
-        astal4
-      ];
+    buildInputs = [
+      glib
+      astal-io
+      astal3
+      astal4
+    ];
 
     preFixup = ''
       gappsWrapperArgs+=(
         --prefix NIX_GI_DIRS : "$(${datadirs})"
-        --prefix PATH : "${lib.makeBinPath (bins ++ extraPackages)}"
+        --prefix PATH : "${lib.makeBinPath bins}"
       )
     '';
 
@@ -82,6 +78,8 @@ in
       "-X main.astalGjs=${astal-gjs}"
       "-X main.gtk4LayerShell=${gtk4-layer-shell}/lib/libgtk4-layer-shell.so"
     ];
+
+    passthru = { inherit wrap; };
 
     meta = {
       homepage = "https://github.com/Aylur/ags";

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -105,14 +105,14 @@ in {
     })
     (let
       pkg = cfg.package.override {
-        extraPackages = cfg.extraPackages;
         astal3 = cfg.astal.gtk3Package;
         astal-io = cfg.astal.ioPackage;
         astal-gjs = "${config.home.homeDirectory}/.local/share/ags";
       };
+      wrapped = pkg.wrap { inherit (cfg) extraPackages; };
     in {
-      programs.ags.finalPackage = pkg;
-      home.packages = [pkg];
+      programs.ags.finalPackage = wrapped;
+      home.packages = [wrapped];
       home.file.".local/share/ags".source = "${cfg.astal.gjsPackage}/share/astal/gjs";
     })
     (mkIf cfg.systemd.enable {

--- a/nix/template/flake.nix
+++ b/nix/template/flake.nix
@@ -2,7 +2,7 @@
   description = "My Awesome Desktop Shell";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
     ags = {
       url = "github:aylur/ags";
@@ -11,9 +11,9 @@
   };
 
   outputs = {
-    self,
     nixpkgs,
     ags,
+    ...
   }: let
     system = "x86_64-linux";
     pkgs = nixpkgs.legacyPackages.${system};
@@ -37,7 +37,7 @@
       default = pkgs.mkShell {
         buildInputs = [
           # includes astal3 astal4 astal-io by default
-          (ags.packages.${system}.default.override {
+          (ags.packages.${system}.default.wrap {
             extraPackages = [
               # cherry pick packages
             ];

--- a/nix/wrap.nix
+++ b/nix/wrap.nix
@@ -1,0 +1,46 @@
+{pkgs, ags}: { extraPackages ? [], allowRewrap ? false }:
+
+let
+  inherit (pkgs.lib) makeBinPath unique;
+
+  wrapped =
+  if extraPackages == []
+  then ags
+  else pkgs.stdenv.mkDerivation {
+    name = "ags-wrapped";
+    dontUnpack = true;
+
+    nativeBuildInputs = with pkgs; [wrapGAppsHook gobject-introspection];
+    buildInputs = with pkgs; [bash glib] ++ extraPackages;
+
+    installPhase = ''
+      mkdir $out/
+      ln -s ${ags}/* $out
+
+      # $out/bin must be recreated manually so wrapGAppsHook can work there
+      rm $out/bin
+      mkdir $out/bin
+      ln -s ${ags}/bin/ags $out/bin/
+    '';
+
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix PATH : "${makeBinPath extraPackages}"
+      )
+    '';
+
+    passthru.wasWrapped = true;
+    meta.mainProgram = "ags";
+  };
+
+in
+
+if ags.wasWrapped or false
+then
+  if allowRewrap
+  then wrapped
+  else
+    if extraPackages == []
+    then ags
+    else ags.override (old: { extraPackages = unique (old.extraPackages ++ extraPackages); })
+else wrapped


### PR DESCRIPTION
Motivation: overring extraPackages resulted in re-compilation of the ags go binary, which was a bit annoying.

Would it be better to implement this function in the `passthru` attributes of `ags` and `agsFull`?

Like(in `nix/default.nix`)

```nix
{
# ...
  passthru.wrapAgs = import ./wrap.nix;
# ...
}
```