### PR TITLE
correct build output file name

### DIFF
--- a/docs/guide/bundling.md
+++ b/docs/guide/bundling.md
@@ -261,7 +261,7 @@ custom_target(
     meson.project_source_root() / 'app.ts',
     main,
   ],
-  output: [meson.project_name()],
+  output: main,
   input: files('app.ts'),
   install: true,
   install_dir: pkgdatadir,


### PR DESCRIPTION
After building, we should have both the executable and the `.wrapped` file installed, but the build script outputs to the wrong filename.

Pretty important fix, since without it, it defeats the purpose of the wrapper file and will fail upon execution