### PR TITLE
nix: fix systemd service

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -126,7 +126,8 @@ in {
 
         Service = {
           ExecStart = "${cfg.finalPackage}/bin/ags run";
-          Restart = "on-failure";
+          Restart = "always";
+          RestartSec = "10";
           KillMode = "mixed";
         };
 


### PR DESCRIPTION
Then using systemd service, it fails on login (with gdm and sddm at least). This PR slightly modifies config so service can work as intended