### PR TITLE
Added an option to use the `--gtk4`-flag in the systemd integration.

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -131,6 +131,7 @@ in {
           Documentation = "https://github.com/Aylur/ags";
           PartOf = ["graphical-session.target"];
           After = ["graphical-session-pre.target"];
+          X-SwitchMethod = "restart";
         };
 
         Service = {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -97,6 +97,15 @@ in {
         Enable systemd integration.
       '';
     };
+
+    systemd.gtk4 = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Switch from gtk3 to gtk4.
+      '';
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -125,7 +134,11 @@ in {
         };
 
         Service = {
-          ExecStart = "${cfg.finalPackage}/bin/ags run";
+          ExecStart = "${cfg.finalPackage}/bin/ags run ${
+            if cfg.systemd.gtk4
+            then "--gtk4"
+            else ""
+          }";
           Restart = "on-failure";
           KillMode = "mixed";
         };


### PR DESCRIPTION
I just added a configuration option to the Home Manager module which allows the user to use the systemd integration with a gtk4 shell. It was missing when I tried to set up ags so I opened and issue. But then I thought "Oh well. Might as well do it yourself." and implemented it myself. So technically this fixes #704 .

Usage:
```nix
programs.ags.systemd = {
  enable = true;
  gtk4 = true;
};
```