### PR TITLE
docs(installation): add Fedora installation instructions

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -18,6 +18,15 @@ nix shell github:aylur/ags
 
 Read more about running AGS on [Nix](./nix)
 
+## Fedora
+
+maintainer: [@solopasha](https://github.com/solopasha)
+
+```sh
+sudo dnf copr enable solopasha/hyprland
+sudo dnf install aylurs-gtk-shell2
+```
+
 ## From Source
 
 1. Install these three


### PR DESCRIPTION
Re-introduces installation instructions for Fedora distribution, following the legacy v1 documentation but with new addition COPR package  `aylurs-gtk-shell2`.