### PR TITLE
fix(nix): Update wrapGAppsHook to wrapGAppsHook3 for nixpkgs compatib…

### DIFF
--- a/docs/guide/nix.md
+++ b/docs/guide/nix.md
@@ -39,7 +39,7 @@ To build a derivation you can use the `ags bundle` command.
       src = ./.;
 
       nativeBuildInputs = with pkgs; [
-        wrapGAppsHook
+        wrapGAppsHook3
         gobject-introspection
         ags.packages.${system}.default
       ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,7 @@
   lib,
   buildGoModule,
   buildNpmPackage,
-  wrapGAppsHook,
+  wrapGAppsHook3,
   gobject-introspection,
   glib,
   gjs,
@@ -90,7 +90,7 @@ in
     proxyVendor = true;
 
     nativeBuildInputs = [
-      wrapGAppsHook
+      wrapGAppsHook3
       gobject-introspection
       installShellFiles
     ];

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -10,7 +10,7 @@
   ];
 
   packages = with pkgs; [
-    wrapGAppsHook
+    wrapGAppsHook3
     gobject-introspection
     libadwaita
   ];

--- a/nix/template/flake.nix
+++ b/nix/template/flake.nix
@@ -39,7 +39,7 @@
         src = ./.;
 
         nativeBuildInputs = with pkgs; [
-          wrapGAppsHook
+          wrapGAppsHook3
           gobject-introspection
           ags.packages.${system}.default
         ];


### PR DESCRIPTION
…ility

- Replace deprecated wrapGAppsHook with wrapGAppsHook3 in all Nix files
- Update nix/default.nix, nix/devshell.nix, nix/template/flake.nix
- Update documentation in docs/guide/nix.md
- Fixes build failures on recent nixpkgs versions where wrapGAppsHook was renamed

This resolves compatibility issues with nixos-unstable and other recent nixpkgs versions.